### PR TITLE
Set lastTimeLogsRetrieved variable before restarting subscriber

### DIFF
--- a/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/RestartServiceBrokerSubscriberStep.java
+++ b/com.sap.cloud.lm.sl.cf.process/src/main/java/com/sap/cloud/lm/sl/cf/process/steps/RestartServiceBrokerSubscriberStep.java
@@ -14,6 +14,12 @@ import org.springframework.stereotype.Component;
 public class RestartServiceBrokerSubscriberStep extends RestartAppStep {
 
     @Override
+    public StepPhase executeAsyncStep(ExecutionWrapper execution) {
+        StepsUtil.setLastTimeLogsRetrieved(execution.getContext());
+        return super.executeAsyncStep(execution);
+    }
+
+    @Override
     protected void onError(String message, Exception e) {
         getStepLogger().warn(e, message);
     }


### PR DESCRIPTION
When restarting a subscriber we monitor the execution of the restart and we use lastTimeLogsRetrieved variable in order to get the logs for a timeframe. The variable was not initialized before restarting the subscriber which later on leads to a NPE.

LMCROSSITXSADEPLOY-2478