### PR TITLE
Verify user password on basic auth call

### DIFF
--- a/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/util/BasicTokenGenerator.java
+++ b/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/util/BasicTokenGenerator.java
@@ -41,6 +41,7 @@ public class BasicTokenGenerator extends TokenGenerator {
         OAuthClient oauthClient = restUtil.createOAuthClientByControllerUrl(applicationConfiguration.getControllerUrl(),
                                                                             applicationConfiguration.shouldSkipSslValidation());
         String[] usernameWithPassword = getUsernameWithPassword(tokenString);
+        oauthClient.init(new CloudCredentials(usernameWithPassword[0], usernameWithPassword[1]));
         Optional<AccessToken> accessToken = tokenReuser.getTokenWithExpirationAfter(usernameWithPassword[0],
                                                                                     Constants.BASIC_TOKEN_RETENTION_TIME_IN_SECONDS);
         if (accessToken.isPresent()) {
@@ -48,7 +49,6 @@ public class BasicTokenGenerator extends TokenGenerator {
                                                                 .getValue(),
                                                      StandardCharsets.UTF_8));
         }
-        oauthClient.init(new CloudCredentials(usernameWithPassword[0], usernameWithPassword[1]));
         OAuth2AccessTokenWithAdditionalInfo oAuth2AccessTokenWithAdditionalInfo = oauthClient.getToken();
         storeAccessToken(buildAccessToken(oAuth2AccessTokenWithAdditionalInfo));
         return oAuth2AccessTokenWithAdditionalInfo;


### PR DESCRIPTION
Basic auth calls store user tokens. When a token for user is stored and available in the db a new call does not check if the password is still valid and returns the token.

The goal is to initiate the oauth client which will try to fetch token and the username/password will be validated