### PR TITLE
Fix 500 when invalid Auth header is provided

### DIFF
--- a/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/Messages.java
+++ b/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/Messages.java
@@ -30,6 +30,7 @@ public final class Messages {
     public static final String BASIC_AUTHENTICATION_IS_NOT_ENABLED_USE_OAUTH_2 = "Basic authentication is not enabled, use OAuth2";
     public static final String INVALID_AUTHENTICATION_PROVIDED = "Invalid authentication provided";
     public static final String NO_AUTHORIZATION_HEADER_WAS_PROVIDED = "No Authorization header was provided!";
+    public static final String INVALID_AUTHORIZATION_HEADER_WAS_PROVIDED = "Invalid Authorization header was provided!";
     public static final String THE_TOKEN_HAS_EXPIRED_ON_0 = "The token has expired on: \"{0}\"";
     public static final String UNSUPPORTED_TOKEN_TYPE = "Unsupported token type: \"{0}\".";
 

--- a/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/security/AuthenticationLoaderFilter.java
+++ b/multiapps-controller-web/src/main/java/org/cloudfoundry/multiapps/controller/web/security/AuthenticationLoaderFilter.java
@@ -63,6 +63,9 @@ public class AuthenticationLoaderFilter extends OncePerRequestFilter {
 
     private OAuth2AccessTokenWithAdditionalInfo generateOauthToken(String authorizationHeaderValue) {
         String[] tokenStringElements = authorizationHeaderValue.split("\\s");
+        if (tokenStringElements.length != 2) {
+            failWithUnauthorized(Messages.INVALID_AUTHORIZATION_HEADER_WAS_PROVIDED);
+        }
         TokenGenerator tokenGenerator = tokenGeneratorFactory.createGenerator(tokenStringElements[0]);
         return tokenGenerator.generate(tokenStringElements[1]);
     }


### PR DESCRIPTION
If invalid Authorization is provided there are cases that might fail with 500