### PR TITLE
Make liquibase schema validation offline

### DIFF
--- a/com.sap.cloud.lm.sl.cf.core/src/main/resources/com/sap/cloud/lm/sl/cf/core/db/changelog/db-changelog-add-access-tokens-table.xml
+++ b/com.sap.cloud.lm.sl.cf.core/src/main/resources/com/sap/cloud/lm/sl/cf/core/db/changelog/db-changelog-add-access-tokens-table.xml
@@ -2,7 +2,7 @@
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet author="sap.com" id="create_table_access_token">
         <preConditions onFail="MARK_RAN">


### PR DESCRIPTION
#### Description: 
Liquibase schema version 3.6 is missing in liquibase jar and liquibase attempts to download it from internet.
This is not possible on systems/CF landscapes w/o external network access


