### PR TITLE
Fix token processing

### DIFF
--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/util/TokenGenerator.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/util/TokenGenerator.java
@@ -7,7 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 
 import org.apache.commons.collections4.MapUtils;
 import org.cloudfoundry.client.lib.oauth2.OAuth2AccessTokenWithAdditionalInfo;
@@ -57,7 +57,7 @@ public abstract class TokenGenerator {
         long expirationInSeconds = ((Number) oAuth2AccessTokenWithAdditionalInfo.getAdditionalInfo()
                                                                                 .get(EXPIRES_AT_KEY)).longValue();
         return Instant.ofEpochSecond(expirationInSeconds)
-                      .atZone(ZoneOffset.UTC)
+                      .atZone(ZoneId.systemDefault())
                       .toLocalDateTime();
     }
 }

--- a/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/util/TokenReuser.java
+++ b/com.sap.cloud.lm.sl.cf.web/src/main/java/com/sap/cloud/lm/sl/cf/web/util/TokenReuser.java
@@ -2,6 +2,7 @@ package com.sap.cloud.lm.sl.cf.web.util;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -71,7 +72,7 @@ public class TokenReuser {
     }
 
     private LocalDateTime getExpirationDate(OAuth2AccessTokenWithAdditionalInfo currentToken) {
-        return LocalDateTime.ofInstant(currentToken.getExpiresAt(), ZoneOffset.UTC);
+        return LocalDateTime.ofInstant(currentToken.getExpiresAt(), ZoneId.systemDefault());
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <javassist.version>3.19.0-GA</javassist.version>
         <javax.annotation-api.version>1.2</javax.annotation-api.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
-        <eclipselink.version>2.7.3</eclipselink.version>
+        <eclipselink.version>2.7.10</eclipselink.version>
         <gson.version>2.9.0</gson.version>
         <snakeyaml.version>1.26</snakeyaml.version>
         <flowable.version>6.4.0</flowable.version>


### PR DESCRIPTION
1. Update eclipse link. The current version cannot compare dates and Hana fails with syntax error because the date is not quoted
2. Use the machine timezone because currently could occur inconsistency in the token comparison which leads to requests with invalid tokens and errors 