### PR TITLE
Add additional logging for clean-up jobs

### DIFF
--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/Messages.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/Messages.java
@@ -247,8 +247,9 @@ public class Messages {
     public static final String SOME_INSTANCES_ARE_DOWN = "Some instances are down. Check the logs of your application for more information.";
     public static final String SOME_INSTANCES_HAVE_CRASHED = "Some instances have crashed. Check the logs of your application for more information.";
     public static final String CLEAN_UP_JOB_STARTED_BY_APPLICATION_INSTANCE_0_AT_1 = "Clean-up job started by application instance {0} at: {1}";
-    public static final String CLEAN_UP_JOB_FINISHED_AT_0 = "Clean-up job finished at: {0}";
+    public static final String CLEAN_UP_JOB_WHICH_STARTED_AT_0_HAS_FINISHED_AT_1 = "Clean-up job, which started at: {0}, has finished at: {1}";
     public static final String WILL_CLEAN_UP_DATA_STORED_BEFORE_0 = "Will clean-up data stored before: {0}";
+    public static final String WILL_DELETE_HISTORIC_PROCESSES_BEFORE_0 = "Will delete Flowable historic processes before: {0}";
     public static final String DELETED_HISTORIC_PROCESSES_0 = "Deleted historic processes: {0}";
     public static final String DELETED_FILES_0 = "Deleted files: {0}";
     public static final String ABORTED_OPERATIONS_0 = "Aborted operations: {0}";
@@ -265,6 +266,7 @@ public class Messages {
     public static final String CREATE_SUPPORT_TICKET_TO_CC_COMPONENT = "If you think the problem is in the controller, please create a support ticket to {0} component \"{1}\".";
     public static final String DELETING_OPERATION_WITH_ID = "Deleting operation with ID \"{0}\"";
     public static final String DELETING_FLOWABLE_PROCESS_WITH_ID = "Deleting Flowable process with ID \"{0}\"";
+    public static final String WILL_DELETE_FLOWABLE_PROCESSES_BEFORE_0 = "Will delete Flowable processes before: {0}";
     public static final String FLOWABLE_PROCESSES_TO_DELETE = "Flowable processes to delete: {0}";
     public static final String APPLICATION_NOT_STAGED_CORRECTLY = "Application \"{0}\" was not staged correctly during the previous deployment";
     public static final String JOB_WITH_ID_AND_TASK_NAME_EXPIRED = "Job with id \"{0}\" and Task name \"{1}\" expired";

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/CleanUpJob.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/CleanUpJob.java
@@ -36,8 +36,9 @@ public class CleanUpJob {
         if (configuration.getApplicationInstanceIndex() != SELECTED_INSTANCE_FOR_CLEAN_UP) {
             return;
         }
+        Instant cleanUpJobStartTime = Instant.now();
         LOGGER.info(LOG_MARKER, format(Messages.CLEAN_UP_JOB_STARTED_BY_APPLICATION_INSTANCE_0_AT_1,
-                                       configuration.getApplicationInstanceIndex(), Instant.now()));
+                                       configuration.getApplicationInstanceIndex(), cleanUpJobStartTime));
 
         Date expirationTime = computeExpirationTime();
         LOGGER.info(LOG_MARKER, format(Messages.WILL_CLEAN_UP_DATA_STORED_BEFORE_0, expirationTime));
@@ -46,7 +47,7 @@ public class CleanUpJob {
             safeExecutor.execute(() -> cleaner.execute(expirationTime));
         }
 
-        LOGGER.info(LOG_MARKER, format(Messages.CLEAN_UP_JOB_FINISHED_AT_0, Instant.now()));
+        LOGGER.info(LOG_MARKER, format(Messages.CLEAN_UP_JOB_WHICH_STARTED_AT_0_HAS_FINISHED_AT_1, cleanUpJobStartTime, Instant.now()));
     }
 
     private Date computeExpirationTime() {

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/FlowableDataCleaner.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/FlowableDataCleaner.java
@@ -1,5 +1,7 @@
 package org.cloudfoundry.multiapps.controller.process.jobs;
 
+import static java.text.MessageFormat.format;
+
 import java.text.MessageFormat;
 import java.util.Date;
 import java.util.List;
@@ -30,6 +32,7 @@ public class FlowableDataCleaner implements Cleaner {
 
     @Override
     public void execute(Date expirationTime) {
+        LOGGER.info(CleanUpJob.LOG_MARKER, format(Messages.WILL_DELETE_FLOWABLE_PROCESSES_BEFORE_0, expirationTime));
         List<ProcessInstance> processInstances = flowableFacade.findAllRunningProcessInstanceStartedBefore(expirationTime);
         LOGGER.info(CleanUpJob.LOG_MARKER, MessageFormat.format(Messages.FLOWABLE_PROCESSES_TO_DELETE, processInstances.size()));
         processInstances.stream()
@@ -42,8 +45,8 @@ public class FlowableDataCleaner implements Cleaner {
             LOGGER.info(CleanUpJob.LOG_MARKER, MessageFormat.format(Messages.DELETING_FLOWABLE_PROCESS_WITH_ID, processInstanceId));
             flowableFacade.deleteProcessInstance(processInstanceId, Operation.State.ABORTED.name());
         } catch (Exception e) {
-            LOGGER.error(CleanUpJob.LOG_MARKER,
-                         MessageFormat.format(Messages.ERROR_DELETING_FLOWABLE_PROCESS_WITH_ID, processInstanceId), e);
+            LOGGER.error(CleanUpJob.LOG_MARKER, MessageFormat.format(Messages.ERROR_DELETING_FLOWABLE_PROCESS_WITH_ID, processInstanceId),
+                         e);
         }
     }
 

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/FlowableHistoricDataCleaner.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/FlowableHistoricDataCleaner.java
@@ -38,6 +38,7 @@ public class FlowableHistoricDataCleaner implements Cleaner {
 
     @Override
     public void execute(Date expirationTime) {
+        LOGGER.info(CleanUpJob.LOG_MARKER, format(Messages.WILL_DELETE_HISTORIC_PROCESSES_BEFORE_0, expirationTime));
         long deletedProcessesCount = 0;
         long expiredProcessesPages = getExpiredProcessesPageCount(expirationTime);
         for (int i = 0; i < expiredProcessesPages; i++) {


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
We've observed that during some of the clean-up job runs, the logs for the clean-up end unexpectedly. 
It's unclear if it's caused by the execution of one of the jobs since there are no logs linked with their start. 

