### PR TITLE
Bump OSS dependencies versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,30 +11,30 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.version>5.8.2</junit.version>
-        <junit-platform.version>1.8.2</junit-platform.version>
-        <mockito.version>4.2.0</mockito.version>
+        <junit.version>5.9.2</junit.version>
+        <junit-platform.version>1.9.2</junit-platform.version>
+        <mockito.version>4.11.0</mockito.version>
         <derby.version>10.14.2.0</derby.version>
         <h2.version>2.1.210</h2.version>
         <servlet-api.version>4.0.4</servlet-api.version>
-        <log4j.version>2.17.1</log4j.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <log4j.version>2.20.0</log4j.version>
+        <slf4j.version>2.0.6</slf4j.version>
         <commons-io.version>2.8.0</commons-io.version>
         <commons-fileupload.version>1.5</commons-fileupload.version>
-        <commons-lang3.version>3.11</commons-lang3.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <snakeyaml.version>1.32</snakeyaml.version>
-        <httpclient.version>4.5.13</httpclient.version>
+        <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>
         <eclipselink.version>2.7.9</eclipselink.version>
         <flowable.version>6.6.0</flowable.version>
         <mybatis.version>3.5.7</mybatis.version>
-        <spring.version>5.3.23</spring.version>
-        <spring-security.version>5.7.5</spring-security.version>
+        <spring.version>5.3.25</spring.version>
+        <spring-security.version>5.7.7</spring-security.version>
         <nimbus-jose-jwt.version>9.10.1</nimbus-jose-jwt.version>
         <hikari.version>3.4.3</hikari.version>
-        <jackson.version>2.13.4</jackson.version>
-        <jackson.databind.version>2.13.4.2</jackson.databind.version>
+        <jackson.version>2.14.2</jackson.version>
+        <jackson.databind.version>2.14.2</jackson.databind.version>
         <liquibase.version>4.9.0</liquibase.version>
         <liquibase-slf4j.version>4.0.0</liquibase-slf4j.version>
         <cloudfoundry-client.version>2.28.0</cloudfoundry-client.version>
@@ -43,15 +43,15 @@
         <jclouds.version>2.5.0</jclouds.version>
         <guice.version>5.0.1</guice.version>
         <gson.version>2.8.9</gson.version>
-        <resilience4j.version>1.5.0</resilience4j.version>
+        <resilience4j.version>1.7.1</resilience4j.version>
         <immutables.version>2.8.8</immutables.version>
-        <micrometer.version>1.5.5</micrometer.version>
+        <micrometer.version>1.10.4</micrometer.version>
         <aliyun-sdk-oss.version>3.15.2</aliyun-sdk-oss.version>
         <jettison.version>1.5.2</jettison.version>
         <auto-service.version>1.0.1</auto-service.version>
         <commons-codec.version>1.15</commons-codec.version>
         <java-cfenv.version>2.4.1</java-cfenv.version>
-        <multiapps.version>2.12.0</multiapps.version>
+        <multiapps.version>2.13.0</multiapps.version>
         <jaxb-api.version>2.3.3</jaxb-api.version>
         <jaxb-core.version>2.3.0.1</jaxb-core.version>
         <jaxb-impl.version>2.3.4</jaxb-impl.version>


### PR DESCRIPTION
* junit to 5.9.2
* junit-platform to 1.9.2
* mockito to 4.11.0
* log4j to 2.20.0
* slf4j to 2.0.6
* httpclient to 4.5.14
* spring to 5.3.25
* spring-security to 5.7.7
* jackson to 2.14.2
* jackson-databind to 2.14.2
* resilience4j to 1.7.1
* micrometer to 1.10.4
* commons-lang3 to 3.12.0

Jira: LMCROSSITXSADEPLOY-2737

