### PR TITLE
Fix duplicate app log issue

### DIFF
--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Constants.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Constants.java
@@ -26,7 +26,6 @@ public class Constants {
 
     // Variables
     public static final String ATTR_CORRELATION_ID = "correlation_id";
-    public static final String LOGS_OFFSET = "logsOffset";
 
     public static final String B3_TRACE_ID_HEADER = "X-B3-TraceId";
     public static final String B3_SPAN_ID_HEADER = "X-B3-SpanId";

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/PollExecuteAppStatusExecution.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/PollExecuteAppStatusExecution.java
@@ -58,7 +58,6 @@ public class PollExecuteAppStatusExecution implements AsyncExecution {
 
     private static final String DEFAULT_SUCCESS_MARKER = "STDOUT:SUCCESS";
     private static final String DEFAULT_FAILURE_MARKER = "STDERR:FAILURE";
-    private static final String LOGS_OFFSET_FOR_APP = "logsOffsetForAppExecution";
 
     @Override
     public AsyncExecutionState execute(ProcessContext context) {
@@ -92,7 +91,7 @@ public class PollExecuteAppStatusExecution implements AsyncExecution {
     // context.getVariable(Variables.LOGS_OFFSET_FOR_APP_EXECUTION) in its place
     private static LocalDateTime getLogOffsetAdapter(ProcessContext context) {
         Object value = context.getExecution()
-                              .getVariable(LOGS_OFFSET_FOR_APP);
+                              .getVariable(Variables.LOGS_OFFSET_FOR_APP_EXECUTION.getName());
         if (value instanceof LogsOffset) {
             return LocalDateTime.ofInstant(((LogsOffset) value).getTimestamp()
                                                                .toInstant(), ZoneId.of("UTC"));

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/StepsUtil.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/StepsUtil.java
@@ -171,7 +171,7 @@ public class StepsUtil {
     // context.getVariable(Variables.LOGS_OFFSET) in its place
     private static LocalDateTime getLogOffsetAdapter(ProcessContext context) {
         Object value = context.getExecution()
-                              .getVariable(org.cloudfoundry.multiapps.controller.core.Constants.LOGS_OFFSET);
+                              .getVariable(Variables.LOGS_OFFSET.getName());
         if (value instanceof LogsOffset) {
             return LocalDateTime.ofInstant(((LogsOffset) value).getTimestamp()
                                                                .toInstant(), ZoneId.of("UTC"));

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/variables/Variables.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/variables/Variables.java
@@ -688,14 +688,18 @@ public interface Variables {
                                                                                                     })
                                                                                                     .defaultValue(Collections.emptyList())
                                                                                                     .build();
-    Variable<LocalDateTime> LOGS_OFFSET_FOR_APP_EXECUTION = ImmutableSimpleVariable.<LocalDateTime> builder()
-                                                                                   .name("logsOffsetForAppExecution")
-                                                                                   .defaultValue(LocalDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
-                                                                                   .build();
-    Variable<LocalDateTime> LOGS_OFFSET = ImmutableSimpleVariable.<LocalDateTime> builder()
-                                                                 .name("logsOffset")
-                                                                 .defaultValue(LocalDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
-                                                                 .build();
+    //we need to use a Json string serialization because the nanosecond precision is being lost when using SimpleVariable
+    Variable<LocalDateTime> LOGS_OFFSET_FOR_APP_EXECUTION = ImmutableJsonStringVariable.<LocalDateTime> builder()
+                                                                                       .name("logsOffsetForAppExecution")
+                                                                                       .type(Variable.typeReference(LocalDateTime.class))
+                                                                                       .defaultValue(LocalDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
+                                                                                       .build();
+    //we need to use a Json string serialization because the nanosecond precision is being lost when using SimpleVariable
+    Variable<LocalDateTime> LOGS_OFFSET = ImmutableJsonStringVariable.<LocalDateTime> builder()
+                                                                     .name("logsOffset")
+                                                                     .type(Variable.typeReference(LocalDateTime.class))
+                                                                     .defaultValue(LocalDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
+                                                                     .build();
 
     Variable<CloudApplication> EXISTING_APP_TO_POLL = ImmutableJsonBinaryVariable.<CloudApplication> builder()
                                                                                  .name("existingAppToPoll")


### PR DESCRIPTION
#### Description: 
The Java native `LocalDateTime` serialization was losing its nanosecond precision when committing to the Flowable db.
Changed the type of the Variable from `SimpleVariable` to `JsonStringVariable` to fix this issue.

