### PR TITLE
Explicitly hint the data source config about the postgresql driver

### DIFF
--- a/multiapps-controller-persistence/pom.xml
+++ b/multiapps-controller-persistence/pom.xml
@@ -202,5 +202,10 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/multiapps-controller-persistence/src/main/java/module-info.java
+++ b/multiapps-controller-persistence/src/main/java/module-info.java
@@ -50,5 +50,6 @@ open module org.cloudfoundry.multiapps.controller.persistence {
 
     requires static java.compiler;
     requires static org.immutables.value;
+    requires org.postgresql.jdbc;
 
 }

--- a/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/util/DataSourceFactory.java
+++ b/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/util/DataSourceFactory.java
@@ -32,6 +32,7 @@ public class DataSourceFactory {
         hikariConfig.setIdleTimeout(60000);
         hikariConfig.setMinimumIdle(10);
         hikariConfig.addDataSourceProperty("tcpKeepAlive", true);
+        hikariConfig.setDriverClassName(org.postgresql.Driver.class.getName());
 
         configureSSLClientKeyIfExists(service, hikariConfig);
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.inject.version>1</javax.inject.version>
         <bouncycastle.version>1.71.1</bouncycastle.version>
+        <postgresql.version>42.6.0</postgresql.version>
     </properties>
     <modules>
         <module>multiapps-controller-client</module>


### PR DESCRIPTION
#### Description:
It seems that in some environments the postgresql driver is not available on the mta controller classpath, thus causing connection to the postgre datatabase fail with `java.lang.RuntimeException: Failed to get driver instance for jdbcUrl=<some-valid-url>`. Here is a separate slack conversation on the issue: https://cloudfoundry.slack.com/archives/C9V0Z8ZPF/p1680505547626489

This PR introduces an explicit dependency to the postgresql driver, its latest is currently `42.6.0`. This seems to solve the issue.

However, one should keep in mind that doing that prevents a buildpack from managing the driver version, e.g. it would not be able to bring potential security fixes without changing this dependency.
