### PR TITLE
Unlock running jobs during app instance restart

### DIFF
--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/Messages.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/Messages.java
@@ -279,6 +279,7 @@ public class Messages {
     public static final String CLEARING_STALE_LOCK_OWNER = "Clearing stale lock owner {0}...";
     public static final String CLEARED_STALE_LOCK_OWNER = "Cleared stale lock owner {0}";
     public static final String SERVICE_BINDING_0_IS_ALREADY_DELETED = "Service binding \"{0}\" is already deleted";
+    public static final String UNLOCKING_JOB_WITH_ID_0_LOCK_EXPIRATION_TIME_1_AND_CREATION_TIME_2 = "Unlocking job with id: \"{0}\", lock expiration time: \"{1}\" and creation time: \"{2}\"";
 
     // Progress messages
     public static final String OPERATION_ID = "Operation ID: {0}";

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/flowable/commands/ClearJobLockOwnersCmd.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/flowable/commands/ClearJobLockOwnersCmd.java
@@ -1,0 +1,44 @@
+package org.cloudfoundry.multiapps.controller.process.flowable.commands;
+
+import java.text.MessageFormat;
+import java.util.List;
+
+import org.cloudfoundry.multiapps.controller.process.Messages;
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.job.api.Job;
+import org.flowable.job.service.JobServiceConfiguration;
+import org.flowable.job.service.impl.persistence.entity.JobEntity;
+import org.flowable.job.service.impl.persistence.entity.JobEntityManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClearJobLockOwnersCmd implements Command<Void> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClearJobLockOwnersCmd.class);
+
+    private final List<Job> lockedJobs;
+    private final JobServiceConfiguration jobServiceConfiguration;
+
+    public ClearJobLockOwnersCmd(List<Job> lockedJobs, JobServiceConfiguration jobServiceConfiguration) {
+        this.lockedJobs = lockedJobs;
+        this.jobServiceConfiguration = jobServiceConfiguration;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        JobEntityManager jobEntityManager = jobServiceConfiguration.getJobEntityManager();
+        for (Job job : lockedJobs) {
+            JobEntity runningLockedJob = jobEntityManager.findById(job.getId());
+            if (runningLockedJob != null) {
+                LOGGER.info(MessageFormat.format(Messages.UNLOCKING_JOB_WITH_ID_0_LOCK_EXPIRATION_TIME_1_AND_CREATION_TIME_2,
+                                                 runningLockedJob.getId(), runningLockedJob.getLockExpirationTime(),
+                                                 runningLockedJob.getCreateTime()));
+                runningLockedJob.setLockOwner(null);
+                runningLockedJob.setLockExpirationTime(null);
+            }
+        }
+        return null;
+    }
+
+}

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/LockOwnerCleaner.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/jobs/LockOwnerCleaner.java
@@ -1,34 +1,34 @@
 package org.cloudfoundry.multiapps.controller.process.jobs;
 
-import org.cloudfoundry.multiapps.controller.persistence.model.LockOwnerEntry;
-import org.cloudfoundry.multiapps.controller.persistence.services.LockOwnerService;
-import org.cloudfoundry.multiapps.controller.process.Messages;
-import org.flowable.engine.ProcessEngine;
-import org.flowable.engine.impl.cmd.ClearProcessInstanceLockTimesCmd;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Scheduled;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.text.MessageFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.cloudfoundry.multiapps.controller.persistence.model.LockOwnerEntry;
+import org.cloudfoundry.multiapps.controller.persistence.services.LockOwnerService;
+import org.cloudfoundry.multiapps.controller.process.Messages;
+import org.cloudfoundry.multiapps.controller.process.util.LockOwnerReleaser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+
 @Named
 public class LockOwnerCleaner {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LockOwnerCleaner.class);
 
-    private final ProcessEngine processEngine;
     private final LockOwnerService lockOwnerService;
+    private final LockOwnerReleaser lockOwnerReleaser;
 
     @Inject
-    public LockOwnerCleaner(ProcessEngine processEngine, LockOwnerService lockOwnerService) {
-        this.processEngine = processEngine;
+    public LockOwnerCleaner(LockOwnerService lockOwnerService, LockOwnerReleaser lockOwnerReleaser) {
         this.lockOwnerService = lockOwnerService;
+        this.lockOwnerReleaser = lockOwnerReleaser;
     }
 
     @Scheduled(fixedRate = 6, timeUnit = TimeUnit.MINUTES)
@@ -41,7 +41,7 @@ public class LockOwnerCleaner {
                                               .map(LockOwnerEntry::getLockOwner)
                                               .collect(Collectors.toList());
         for (var staleLockOwner : staleLockOwners) {
-            clearStaleLockOwner(staleLockOwner);
+            releaseStaleLockOwner(staleLockOwner);
         }
         if (!staleLockOwners.isEmpty()) {
             lockOwnerService.createQuery()
@@ -50,15 +50,15 @@ public class LockOwnerCleaner {
         }
     }
 
-    private void clearStaleLockOwner(String staleLockOwner) {
+    private void releaseStaleLockOwner(String staleLockOwner) {
         LOGGER.info(MessageFormat.format(Messages.CLEARING_STALE_LOCK_OWNER, staleLockOwner));
         try {
-            processEngine.getProcessEngineConfiguration()
-                         .getCommandExecutor()
-                         .execute(new ClearProcessInstanceLockTimesCmd(staleLockOwner));
+            lockOwnerReleaser.release(staleLockOwner);
             LOGGER.info(MessageFormat.format(Messages.CLEARED_STALE_LOCK_OWNER, staleLockOwner));
         } catch (Exception e) {
-            LOGGER.error(MessageFormat.format(Messages.CLEARING_STALE_FLOWABLE_LOCK_OWNER_0_THREW_AN_EXCEPTION_1, staleLockOwner, e.getMessage()), e);
+            LOGGER.error(MessageFormat.format(Messages.CLEARING_STALE_FLOWABLE_LOCK_OWNER_0_THREW_AN_EXCEPTION_1, staleLockOwner,
+                                              e.getMessage()),
+                         e);
         }
     }
 

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/LockOwnerReleaser.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/LockOwnerReleaser.java
@@ -1,0 +1,54 @@
+package org.cloudfoundry.multiapps.controller.process.util;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.cloudfoundry.multiapps.controller.process.flowable.commands.ClearJobLockOwnersCmd;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.impl.cmd.ClearProcessInstanceLockTimesCmd;
+import org.flowable.job.api.Job;
+import org.flowable.job.service.JobServiceConfiguration;
+
+@Named("lockOwnerReleaser")
+public class LockOwnerReleaser {
+
+    private final ProcessEngine processEngine;
+
+    @Inject
+    public LockOwnerReleaser(ProcessEngine processEngine) {
+        this.processEngine = processEngine;
+    }
+
+    public void release(String lockOwner) {
+        clearProcessInstanceLockTime(lockOwner);
+        clearJobsLockTime(lockOwner);
+    }
+
+    private void clearProcessInstanceLockTime(String lockOwner) {
+        processEngine.getProcessEngineConfiguration()
+                     .getCommandExecutor()
+                     .execute(new ClearProcessInstanceLockTimesCmd(lockOwner));
+    }
+
+    private void clearJobsLockTime(String lockOwner) {
+        JobServiceConfiguration jobServiceConfiguration = processEngine.getProcessEngineConfiguration()
+                                                                       .getAsyncExecutor()
+                                                                       .getJobServiceConfiguration();
+        List<Job> jobs = getStaleJobs(lockOwner);
+        if (CollectionUtils.isNotEmpty(jobs)) {
+            processEngine.getManagementService()
+                         .executeCommand(new ClearJobLockOwnersCmd(jobs, jobServiceConfiguration));
+        }
+    }
+
+    private List<Job> getStaleJobs(String lockOwner) {
+        return processEngine.getManagementService()
+                            .createJobQuery()
+                            .lockOwner(lockOwner)
+                            .list();
+    }
+
+}


### PR DESCRIPTION
When app instance crashes / flowable engine gets shutdown a lock_owner and lock_exp_time should also be removed from act_ru_jobs and the process lock_owner and lock_time should be removed.
The commit removes the lock_onwer and time in act_ru_job
Flowable forum thread: https://forum.flowable.org/t/clear-lock-owner-and-lock-exp-time-from-act-ru-job/10465
