### PR TITLE
Increase version of multiple dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,27 +20,27 @@
         <derby.version>10.14.2.0</derby.version>
         <h2.version>2.1.210</h2.version>
         <servlet-api.version>4.0.4</servlet-api.version>
-        <log4j.version>2.20.0</log4j.version>
-        <slf4j.version>2.0.7</slf4j.version>
+        <log4j.version>2.22.1</log4j.version>
+        <slf4j.version>2.0.11</slf4j.version>
         <commons-io.version>2.8.0</commons-io.version>
         <commons-fileupload.version>1.5</commons-fileupload.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-collections4.version>4.4</commons-collections4.version>
-        <snakeyaml.version>2.0</snakeyaml.version>
+        <snakeyaml.version>2.2</snakeyaml.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>
         <eclipselink.version>2.7.12</eclipselink.version>
         <flowable.version>6.8.0</flowable.version>
         <mybatis.version>3.5.7</mybatis.version>
-        <spring.version>5.3.30</spring.version>
-        <spring-security.version>5.8.7</spring-security.version>
+        <spring.version>5.3.31</spring.version>
+        <spring-security.version>5.8.9</spring-security.version>
         <json-smart.version>2.4.9</json-smart.version>
         <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>
         <hikari.version>5.0.1</hikari.version>
-        <jackson.version>2.15.0</jackson.version>
-        <jackson.databind.version>2.15.0</jackson.databind.version>
-        <liquibase.version>4.22.0</liquibase.version>
-        <liquibase-slf4j.version>4.1.0</liquibase-slf4j.version>
+        <jackson.version>2.16.1</jackson.version>
+        <jackson.databind.version>2.16.1</jackson.databind.version>
+        <liquibase.version>4.25.1</liquibase.version>
+        <liquibase-slf4j.version>5.0.0</liquibase-slf4j.version>
         <cloudfoundry-client.version>2.40.0</cloudfoundry-client.version>
         <swagger.version>1.6.9</swagger.version>
         <jclouds.version>2.5.0</jclouds.version>


### PR DESCRIPTION
log4j - 2.22.1
slf4j - 2.0.11
snakeyaml - 2.2
spring - 5.3.31 - incresed due to included comptability change for log4j 2.21 spring-security - 5.8.9
jackson - 2.16.1
jackson-databind - 2.16.1
liquibase - 4.25.1 - required in order to adopt latest version of log4j liquibase-slf4j - 5.0.0


