### PR TITLE
LMCROSSITXSADEPLOY-2945 [XSA] Bump OSS dependencies versions for Spring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
         <flowable.version>6.4.0</flowable.version>
         <mybatis.version>3.5.6</mybatis.version>
         <joda-time.version>2.8</joda-time.version>
-        <spring.version>5.3.29</spring.version>
-        <spring.security.version>5.8.5</spring.security.version>
+        <spring.version>5.3.34</spring.version>
+        <spring.security.version>5.8.11</spring.security.version>
         <spring.security.jwt.version>1.1.1.RELEASE</spring.security.jwt.version>
         <spring.cloud.version>2.0.9.RELEASE</spring.cloud.version>
         <spring.cloud.core.version>1.2.9.RELEASE</spring.cloud.core.version>


### PR DESCRIPTION
Bump Spring version to 5.3.34 and Spring security to 5.8.11

