### PR TITLE
Explicitly hint the data source config about the postgresql driver

### DIFF
--- a/multiapps-controller-persistence/pom.xml
+++ b/multiapps-controller-persistence/pom.xml
@@ -216,5 +216,9 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/multiapps-controller-persistence/src/main/java/module-info.java
+++ b/multiapps-controller-persistence/src/main/java/module-info.java
@@ -51,5 +51,5 @@ open module org.cloudfoundry.multiapps.controller.persistence {
 
     requires static java.compiler;
     requires static org.immutables.value;
-
+    requires org.postgresql.jdbc;
 }

--- a/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/util/DataSourceFactory.java
+++ b/multiapps-controller-persistence/src/main/java/org/cloudfoundry/multiapps/controller/persistence/util/DataSourceFactory.java
@@ -6,6 +6,7 @@ import javax.inject.Named;
 import javax.sql.DataSource;
 
 import org.cloudfoundry.multiapps.controller.persistence.Constants;
+import org.postgresql.Driver;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -32,6 +33,7 @@ public class DataSourceFactory {
         hikariConfig.setIdleTimeout(60000);
         hikariConfig.setMinimumIdle(10);
         hikariConfig.addDataSourceProperty("tcpKeepAlive", true);
+        hikariConfig.setDriverClassName(Driver.class.getName());
 
         configureSSLClientKeyIfExists(service, hikariConfig);
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.inject.version>1</javax.inject.version>
         <bouncycastle.version>1.78</bouncycastle.version>
+        <postgresql.version>42.7.3</postgresql.version>
     </properties>
     <modules>
         <module>multiapps-controller-client</module>
@@ -858,6 +859,11 @@
                 <groupId>org.cloudfoundry.multiapps</groupId>
                 <artifactId>multiapps-controller-shutdown-client</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Tested with UPS that is created by the binding from another app. UPS example:
{
   "dbname":"db-name",
   "hostname":"<hostname>",
   "password":"<password>",
   "port":"<port>",
   "sslcert":"<sslcert>",
   "sslrootcert":"<sslrootcert>",
   "uri":"<uri>",
   "username":"<username>"
}

The DB name must be deploy-service databae