### PR TITLE
[LMCROSSITXSADEPLOY-3316] Introduce health-check-interval MTA module parameter

### DIFF
--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcess.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcess.java
@@ -23,11 +23,13 @@ public abstract class RawCloudProcess extends RawCloudEntity<CloudProcess> {
         Integer healthCheckTimeout = null;
         String healthCheckHttpEndpoint = null;
         Integer healthCheckInvocationTimeout = null;
+        Integer healthCheckInterval = null;
         if (healthCheck.getData() != null) {
             Data healthCheckData = healthCheck.getData();
             healthCheckTimeout = healthCheckData.getTimeout();
             healthCheckInvocationTimeout = healthCheckData.getInvocationTimeout();
             healthCheckHttpEndpoint = healthCheckData.getEndpoint();
+            healthCheckInterval = healthCheckData.getInterval();
         }
         Integer readinessHealthCheckInvocationTimeout = null;
         String readinessHealthCheckHttpEndpoint = null;
@@ -49,6 +51,7 @@ public abstract class RawCloudProcess extends RawCloudEntity<CloudProcess> {
                                     .healthCheckHttpEndpoint(healthCheckHttpEndpoint)
                                     .healthCheckTimeout(healthCheckTimeout)
                                     .healthCheckInvocationTimeout(healthCheckInvocationTimeout)
+                                    .healthCheckInterval(healthCheckInterval)
                                     .readinessHealthCheckType(readinessHealthCheckType.getType()
                                                                                       .getValue())
                                     .readinessHealthCheckHttpEndpoint(readinessHealthCheckHttpEndpoint)

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/CloudProcess.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/CloudProcess.java
@@ -33,6 +33,9 @@ public abstract class CloudProcess extends CloudEntity implements Derivable<Clou
     public abstract Integer getReadinessHealthCheckInterval();
 
     @Nullable
+    public abstract Integer getHealthCheckInterval();
+
+    @Nullable
     public abstract Integer getReadinessHealthCheckInvocationTimeout();
 
     @Nullable

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/Staging.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/Staging.java
@@ -57,6 +57,12 @@ public interface Staging {
     Integer getReadinessHealthCheckInterval();
 
     /**
+     * @return liveness health check interval in seconds, or null to use the CF platform default
+     */
+    @Nullable
+    Integer getHealthCheckInterval();
+
+    /**
      * @return readiness health check timeout
      */
     @Nullable

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerRestClientImpl.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerRestClientImpl.java
@@ -392,7 +392,7 @@ public class CloudControllerRestClientImpl implements CloudControllerRestClient 
         UpdateProcessRequest.Builder updateProcessRequestBuilder = UpdateProcessRequest.builder()
                                                                                        .processId(getApplicationProcessResponse.getId())
                                                                                        .command(staging.getCommand());
-        if (staging.getHealthCheckType() != null) {
+        if (staging.getHealthCheckType() != null || staging.getHealthCheckInterval() != null) {
             updateProcessRequestBuilder.healthCheck(buildHealthCheck(staging));
         }
         if (staging.getReadinessHealthCheckType() != null) {
@@ -438,15 +438,17 @@ public class CloudControllerRestClientImpl implements CloudControllerRestClient 
     }
 
     private HealthCheck buildHealthCheck(Staging staging) {
-        HealthCheckType healthCheckType = HealthCheckType.from(staging.getHealthCheckType());
-        return HealthCheck.builder()
-                          .type(healthCheckType)
-                          .data(Data.builder()
-                                    .endpoint(staging.getHealthCheckHttpEndpoint())
-                                    .timeout(staging.getHealthCheckTimeout())
-                                    .invocationTimeout(staging.getInvocationTimeout())
-                                    .build())
-                          .build();
+        HealthCheck.Builder healthCheckBuilder = HealthCheck.builder()
+                                                            .data(Data.builder()
+                                                                      .endpoint(staging.getHealthCheckHttpEndpoint())
+                                                                      .timeout(staging.getHealthCheckTimeout())
+                                                                      .invocationTimeout(staging.getInvocationTimeout())
+                                                                      .interval(staging.getHealthCheckInterval())
+                                                                      .build());
+        if (staging.getHealthCheckType() != null) {
+            healthCheckBuilder.type(HealthCheckType.from(staging.getHealthCheckType()));
+        }
+        return healthCheckBuilder.build();
     }
 
     private void addRoutes(Set<CloudRoute> routes, UUID applicationGuid) {

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfo.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfo.java
@@ -11,12 +11,14 @@ public class HealthCheckInfo {
     private final Integer timeout;
     private final Integer invocationTimeout;
     private final String httpEndpoint;
+    private final Integer interval;
 
-    private HealthCheckInfo(String type, Integer timeout, Integer invocationTimeout, String httpEndpoint) {
+    private HealthCheckInfo(String type, Integer timeout, Integer invocationTimeout, String httpEndpoint, Integer interval) {
         this.type = type;
         this.timeout = timeout;
         this.invocationTimeout = invocationTimeout;
         this.httpEndpoint = httpEndpoint;
+        this.interval = interval;
     }
 
     public static HealthCheckInfo fromStaging(Staging staging) {
@@ -27,7 +29,8 @@ public class HealthCheckInfo {
         var timeout = staging.getHealthCheckTimeout();
         var invocationTimeout = staging.getInvocationTimeout();
         var httpEndpoint = staging.getHealthCheckHttpEndpoint();
-        return new HealthCheckInfo(type, timeout, invocationTimeout, httpEndpoint);
+        var interval = staging.getHealthCheckInterval();
+        return new HealthCheckInfo(type, timeout, invocationTimeout, httpEndpoint, interval);
     }
 
     public static HealthCheckInfo fromProcess(CloudProcess process) {
@@ -35,7 +38,8 @@ public class HealthCheckInfo {
         var timeout = process.getHealthCheckTimeout();
         var invocationTimeout = process.getHealthCheckInvocationTimeout();
         var httpEndpoint = process.getHealthCheckHttpEndpoint();
-        return new HealthCheckInfo(type.toString(), timeout, invocationTimeout, httpEndpoint);
+        var interval = process.getHealthCheckInterval();
+        return new HealthCheckInfo(type.toString(), timeout, invocationTimeout, httpEndpoint, interval);
     }
 
     public String getType() {
@@ -54,6 +58,10 @@ public class HealthCheckInfo {
         return httpEndpoint;
     }
 
+    public Integer getInterval() {
+        return interval;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -66,6 +74,7 @@ public class HealthCheckInfo {
         return Objects.equals(getType(), other.getType())
             && Objects.equals(getTimeout(), other.getTimeout())
             && Objects.equals(getInvocationTimeout(), other.getInvocationTimeout())
-            && Objects.equals(getHttpEndpoint(), other.getHttpEndpoint());
+            && Objects.equals(getHttpEndpoint(), other.getHttpEndpoint())
+            && Objects.equals(getInterval(), other.getInterval());
     }
 }

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcessTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcessTest.java
@@ -1,0 +1,118 @@
+package org.cloudfoundry.multiapps.controller.client.facade.adapters;
+
+import org.cloudfoundry.client.v3.Metadata;
+import org.cloudfoundry.client.v3.Relationship;
+import org.cloudfoundry.client.v3.ToOneRelationship;
+import org.cloudfoundry.client.v3.processes.Data;
+import org.cloudfoundry.client.v3.processes.HealthCheck;
+import org.cloudfoundry.client.v3.processes.HealthCheckType;
+import org.cloudfoundry.client.v3.processes.ProcessRelationships;
+import org.cloudfoundry.client.v3.processes.ProcessResource;
+import org.cloudfoundry.client.v3.processes.ReadinessHealthCheck;
+import org.cloudfoundry.client.v3.processes.ReadinessHealthCheckType;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.CloudProcess;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RawCloudProcessTest {
+
+    private static final String PROCESS_ID = "0d6b6f94-2e9b-4f62-9c3a-bdf9a7e4d1d0";
+    private static final String CREATED_AT = "2024-01-26T10:00:00Z";
+    private static final String COMMAND = "start";
+    private static final Integer INSTANCES = 2;
+    private static final Integer MEMORY_IN_MB = 256;
+    private static final Integer DISK_IN_MB = 1024;
+    private static final Integer HEALTH_CHECK_TIMEOUT = 60;
+    private static final Integer HEALTH_CHECK_INVOCATION_TIMEOUT = 5;
+    private static final String HEALTH_CHECK_HTTP_ENDPOINT = "/health";
+    private static final Integer HEALTH_CHECK_INTERVAL = 15;
+
+    @Test
+    void testDeriveMapsHealthCheckIntervalFromData() {
+        RawCloudProcess raw = buildRawProcess(buildHealthCheck(HEALTH_CHECK_INTERVAL), buildReadinessHealthCheck());
+
+        CloudProcess derived = raw.derive();
+
+        assertEquals(HEALTH_CHECK_INTERVAL, derived.getHealthCheckInterval());
+        assertEquals(HEALTH_CHECK_TIMEOUT, derived.getHealthCheckTimeout());
+        assertEquals(HEALTH_CHECK_INVOCATION_TIMEOUT, derived.getHealthCheckInvocationTimeout());
+        assertEquals(HEALTH_CHECK_HTTP_ENDPOINT, derived.getHealthCheckHttpEndpoint());
+    }
+
+    @Test
+    void testDeriveLeavesHealthCheckIntervalNullWhenAbsentFromData() {
+        HealthCheck healthCheck = HealthCheck.builder()
+                                             .type(HealthCheckType.HTTP)
+                                             .data(Data.builder()
+                                                       .timeout(HEALTH_CHECK_TIMEOUT)
+                                                       .invocationTimeout(HEALTH_CHECK_INVOCATION_TIMEOUT)
+                                                       .endpoint(HEALTH_CHECK_HTTP_ENDPOINT)
+                                                       .build())
+                                             .build();
+        RawCloudProcess raw = buildRawProcess(healthCheck, buildReadinessHealthCheck());
+
+        CloudProcess derived = raw.derive();
+
+        assertNull(derived.getHealthCheckInterval());
+        assertEquals(HEALTH_CHECK_TIMEOUT, derived.getHealthCheckTimeout());
+    }
+
+    @Test
+    void testDeriveLeavesHealthCheckIntervalNullWhenDataIsNull() {
+        HealthCheck healthCheck = HealthCheck.builder()
+                                             .type(HealthCheckType.PORT)
+                                             .build();
+        RawCloudProcess raw = buildRawProcess(healthCheck, buildReadinessHealthCheck());
+
+        CloudProcess derived = raw.derive();
+
+        assertNull(derived.getHealthCheckInterval());
+        assertNull(derived.getHealthCheckTimeout());
+        assertNull(derived.getHealthCheckInvocationTimeout());
+        assertNull(derived.getHealthCheckHttpEndpoint());
+    }
+
+    private static HealthCheck buildHealthCheck(Integer interval) {
+        return HealthCheck.builder()
+                          .type(HealthCheckType.HTTP)
+                          .data(Data.builder()
+                                    .timeout(HEALTH_CHECK_TIMEOUT)
+                                    .invocationTimeout(HEALTH_CHECK_INVOCATION_TIMEOUT)
+                                    .endpoint(HEALTH_CHECK_HTTP_ENDPOINT)
+                                    .interval(interval)
+                                    .build())
+                          .build();
+    }
+
+    private static ReadinessHealthCheck buildReadinessHealthCheck() {
+        return ReadinessHealthCheck.builder()
+                                   .type(ReadinessHealthCheckType.PROCESS)
+                                   .build();
+    }
+
+    private static RawCloudProcess buildRawProcess(HealthCheck healthCheck, ReadinessHealthCheck readinessHealthCheck) {
+        ProcessResource processResource = ProcessResource.builder()
+                                                         .id(PROCESS_ID)
+                                                         .createdAt(CREATED_AT)
+                                                         .type("web")
+                                                         .command(COMMAND)
+                                                         .instances(INSTANCES)
+                                                         .memoryInMb(MEMORY_IN_MB)
+                                                         .diskInMb(DISK_IN_MB)
+                                                         .healthCheck(healthCheck)
+                                                         .readinessHealthCheck(readinessHealthCheck)
+                                                         .metadata(Metadata.builder()
+                                                                           .build())
+                                                         .relationships(ProcessRelationships.builder()
+                                                                                            .app(ToOneRelationship.builder()
+                                                                                                                  .data(Relationship.builder()
+                                                                                                                                    .id("app-guid")
+                                                                                                                                    .build())
+                                                                                                                  .build())
+                                                                                            .build())
+                                                         .build();
+        return ImmutableRawCloudProcess.of(processResource);
+    }
+}

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfoTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfoTest.java
@@ -1,0 +1,79 @@
+package org.cloudfoundry.multiapps.controller.client.lib.domain;
+
+import org.cloudfoundry.multiapps.controller.client.facade.domain.HealthCheckType;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableCloudProcess;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableStaging;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class HealthCheckInfoTest {
+
+    @Test
+    void testEqualHealthCheckInfoObjectsAreEqual() {
+        ImmutableStaging staging = ImmutableStaging.builder()
+                                                   .healthCheckType("http")
+                                                   .healthCheckInterval(15)
+                                                   .build();
+        HealthCheckInfo first = HealthCheckInfo.fromStaging(staging);
+        HealthCheckInfo second = HealthCheckInfo.fromStaging(staging);
+
+        assertEquals(first, second);
+    }
+
+    @Test
+    void testHealthCheckInfoWithDifferentIntervalsAreNotEqual() {
+        ImmutableStaging stagingWithInterval15 = ImmutableStaging.builder()
+                                                                 .healthCheckType("http")
+                                                                 .healthCheckInterval(15)
+                                                                 .build();
+        ImmutableStaging stagingWithInterval30 = ImmutableStaging.builder()
+                                                                 .healthCheckType("http")
+                                                                 .healthCheckInterval(30)
+                                                                 .build();
+
+        HealthCheckInfo first = HealthCheckInfo.fromStaging(stagingWithInterval15);
+        HealthCheckInfo second = HealthCheckInfo.fromStaging(stagingWithInterval30);
+
+        assertNotEquals(first, second);
+    }
+
+    @Test
+    void testHealthCheckInfoIntervalNullVsNonNullAreNotEqual() {
+        ImmutableStaging stagingWithInterval = ImmutableStaging.builder()
+                                                               .healthCheckType("http")
+                                                               .healthCheckInterval(15)
+                                                               .build();
+        ImmutableStaging stagingWithoutInterval = ImmutableStaging.builder()
+                                                                  .healthCheckType("http")
+                                                                  .build();
+
+        HealthCheckInfo withInterval = HealthCheckInfo.fromStaging(stagingWithInterval);
+        HealthCheckInfo withoutInterval = HealthCheckInfo.fromStaging(stagingWithoutInterval);
+
+        assertNotEquals(withInterval, withoutInterval);
+    }
+
+    @Test
+    void testHealthCheckInfoFromProcessWithInterval() {
+        ImmutableCloudProcess process = ImmutableCloudProcess.builder()
+                                                             .command("start")
+                                                             .diskInMb(256)
+                                                             .instances(1)
+                                                             .memoryInMb(512)
+                                                             .healthCheckType(HealthCheckType.HTTP)
+                                                             .healthCheckInterval(15)
+                                                             .build();
+
+        HealthCheckInfo fromProcess = HealthCheckInfo.fromProcess(process);
+
+        ImmutableStaging staging = ImmutableStaging.builder()
+                                                   .healthCheckType("http")
+                                                   .healthCheckInterval(15)
+                                                   .build();
+        HealthCheckInfo fromStaging = HealthCheckInfo.fromStaging(staging);
+
+        assertEquals(fromProcess, fromStaging);
+    }
+}

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Messages.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Messages.java
@@ -88,6 +88,7 @@ public final class Messages {
     public static final String ERROR_OCCURRED_WHILE_CHECKING_DATABASE_INSTANCE_0 = "Error occurred while checking database instance: \"{0}\"";
     public static final String DOCKER_INFO_NOT_ALLOWED_WITH_LIFECYCLE = "Docker information must not be provided when lifecycle is set to \"{0}\"";
     public static final String UNSUPPORTED_LIFECYCLE_VALUE = "Unsupported lifecycle value: \"{0}\"";
+    public static final String INVALID_HEALTH_CHECK_INTERVAL = "Parameter \"health-check-interval\" must be a positive integer greater than 0, but was: {0}";
     public static final String BUILDPACKS_REQUIRED_FOR_CNB = "Buildpacks must be provided when lifecycle is set to 'cnb'.";
     public static final String DOCKER_INFO_REQUIRED = "Docker information must be provided when lifecycle is set to 'docker'.";
     public static final String BUILDPACKS_NOT_ALLOWED_WITH_DOCKER = "Buildpacks must not be provided when lifecycle is set to 'docker'.";

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/SupportedParameters.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/SupportedParameters.java
@@ -67,6 +67,7 @@ public class SupportedParameters {
     public static final String READINESS_HEALTH_CHECK_HTTP_ENDPOINT = "readiness-health-check-http-endpoint";
     public static final String READINESS_HEALTH_CHECK_INVOCATION_TIMEOUT = "readiness-health-check-invocation-timeout";
     public static final String READINESS_HEALTH_CHECK_INTERVAL = "readiness-health-check-interval";
+    public static final String HEALTH_CHECK_INTERVAL = "health-check-interval";
     public static final String UPLOAD_TIMEOUT = "upload-timeout";
     public static final String STAGE_TIMEOUT = "stage-timeout";
     public static final String START_TIMEOUT = "start-timeout";
@@ -190,6 +191,7 @@ public class SupportedParameters {
                                                                DEPENDENCY_TYPE, DISK_QUOTA, DOCKER, DOMAIN, DOMAINS, DEFAULT_DOMAIN,
                                                                ENABLE_SSH, ENABLE_PARALLEL_SERVICE_BINDINGS, HEALTH_CHECK_HTTP_ENDPOINT,
                                                                HEALTH_CHECK_TIMEOUT, HEALTH_CHECK_INVOCATION_TIMEOUT, HEALTH_CHECK_TYPE,
+                                                               HEALTH_CHECK_INTERVAL,
                                                                HOST, HOSTS, IDLE_DOMAIN, IDLE_DOMAINS, IDLE_HOST, IDLE_HOSTS, IDLE_ROUTES,
                                                                INSTANCES, KEEP_EXISTING_APPLICATION_ATTRIBUTES_UPDATE_STRATEGY,
                                                                KEEP_EXISTING_ROUTES, MEMORY, NO_ROUTE, NO_START, RESTART_ON_ENV_CHANGE,

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
@@ -20,6 +20,7 @@ import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_NOT
 import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_REQUIRED_FOR_CNB;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_NOT_ALLOWED_WITH_LIFECYCLE;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_REQUIRED;
+import static org.cloudfoundry.multiapps.controller.core.Messages.INVALID_HEALTH_CHECK_INTERVAL;
 import static org.cloudfoundry.multiapps.controller.core.Messages.UNSUPPORTED_LIFECYCLE_VALUE;
 
 public class StagingParametersParser implements ParametersParser<Staging> {
@@ -53,6 +54,9 @@ public class StagingParametersParser implements ParametersParser<Staging> {
         Integer readinessHealthCheckInterval = (Integer) PropertiesUtil.getPropertyValue(parametersList,
                                                                                          SupportedParameters.READINESS_HEALTH_CHECK_INTERVAL,
                                                                                          null);
+        Integer healthCheckInterval = (Integer) PropertiesUtil.getPropertyValue(parametersList,
+                                                                                SupportedParameters.HEALTH_CHECK_INTERVAL,
+                                                                                null);
         Boolean isSshEnabled = (Boolean) PropertiesUtil.getPropertyValue(parametersList, SupportedParameters.ENABLE_SSH, null);
         Map<String, Boolean> appFeatures = getAppFeatures(parametersList);
         overrideSshFeatureIfMissing(appFeatures, isSshEnabled);
@@ -60,6 +64,7 @@ public class StagingParametersParser implements ParametersParser<Staging> {
         LifecycleType lifecycleType = parseLifecycleType(parametersList);
 
         validateLifecycleType(lifecycleType, buildpacks, dockerInfo);
+        validateHealthCheckInterval(healthCheckInterval);
 
         return ImmutableStaging.builder()
                                .command(command)
@@ -69,6 +74,7 @@ public class StagingParametersParser implements ParametersParser<Staging> {
                                .invocationTimeout(healthCheckInvocationTimeout)
                                .healthCheckType(healthCheckType)
                                .healthCheckHttpEndpoint(healthCheckHttpEndpoint)
+                               .healthCheckInterval(healthCheckInterval)
                                .readinessHealthCheckType(readinessHealthCheckType)
                                .readinessHealthCheckHttpEndpoint(readinessHealthCheckHttpEndpoint)
                                .readinessHealthCheckInvocationTimeout(readinessHealthCheckInvocationTimeout)
@@ -139,6 +145,12 @@ public class StagingParametersParser implements ParametersParser<Staging> {
 
     private String getDefaultHealthCheckHttpEndpoint(String healthCheckType) {
         return HTTP_HEALTH_CHECK_TYPE.equals(healthCheckType) ? DEFAULT_HEALTH_CHECK_HTTP_ENDPOINT : null;
+    }
+
+    private void validateHealthCheckInterval(Integer healthCheckInterval) {
+        if (healthCheckInterval != null && healthCheckInterval <= 0) {
+            throw new ContentException(MessageFormat.format(INVALID_HEALTH_CHECK_INTERVAL, healthCheckInterval));
+        }
     }
 
 }

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
@@ -17,10 +17,12 @@ import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_NOT
 import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_REQUIRED_FOR_CNB;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_NOT_ALLOWED_WITH_LIFECYCLE;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_REQUIRED;
+import static org.cloudfoundry.multiapps.controller.core.Messages.INVALID_HEALTH_CHECK_INTERVAL;
 import static org.cloudfoundry.multiapps.controller.core.Messages.UNSUPPORTED_LIFECYCLE_VALUE;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACK;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACKS;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.DOCKER;
+import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.HEALTH_CHECK_INTERVAL;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.LIFECYCLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -136,6 +138,31 @@ class StagingParametersParserTest {
         assertNull(staging.getLifecycleType());
         assertTrue(CollectionUtils.isEmpty(staging.getBuildpacks()));
         assertNull(staging.getDockerInfo());
+    }
+
+    @Test
+    void testHealthCheckIntervalIsParsedCorrectly() {
+        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, 15));
+
+        Staging staging = parser.parse(parametersList);
+
+        assertNotNull(staging);
+        assertEquals(15, staging.getHealthCheckInterval());
+    }
+
+    @Test
+    void testHealthCheckIntervalValidationRejectsNonPositiveValue() {
+        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, 0));
+
+        ContentException exception = assertThrows(ContentException.class, () -> parser.parse(parametersList));
+        assertEquals(MessageFormat.format(INVALID_HEALTH_CHECK_INTERVAL, 0), exception.getMessage());
+    }
+
+    @Test
+    void testHealthCheckIntervalIsNullWhenAbsent() {
+        Staging staging = parser.parse(parametersList);
+
+        assertNull(staging.getHealthCheckInterval());
     }
 
     private static Map<String, Object> mapOf(String key, Object value) {

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
@@ -5,12 +5,16 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.cloudfoundry.multiapps.common.ContentException;
 import org.cloudfoundry.multiapps.controller.client.facade.domain.LifecycleType;
 import org.cloudfoundry.multiapps.controller.client.facade.domain.Staging;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.util.CollectionUtils;
 
 import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_NOT_ALLOWED_WITH_DOCKER;
@@ -150,12 +154,39 @@ class StagingParametersParserTest {
         assertEquals(15, staging.getHealthCheckInterval());
     }
 
+    static Stream<Arguments> testHealthCheckIntervalAcceptsPositiveValues() {
+        return Stream.of(Arguments.of(1), Arguments.of(15), Arguments.of(60), Arguments.of(Integer.MAX_VALUE));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testHealthCheckIntervalAcceptsPositiveValues(int interval) {
+        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, interval));
+
+        Staging staging = parser.parse(parametersList);
+
+        assertEquals(interval, staging.getHealthCheckInterval());
+    }
+
     @Test
     void testHealthCheckIntervalValidationRejectsNonPositiveValue() {
         parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, 0));
 
         ContentException exception = assertThrows(ContentException.class, () -> parser.parse(parametersList));
         assertEquals(MessageFormat.format(INVALID_HEALTH_CHECK_INTERVAL, 0), exception.getMessage());
+    }
+
+    static Stream<Arguments> testHealthCheckIntervalValidationRejectsNonPositiveValues() {
+        return Stream.of(Arguments.of(0), Arguments.of(-1), Arguments.of(-15), Arguments.of(Integer.MIN_VALUE));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testHealthCheckIntervalValidationRejectsNonPositiveValues(int interval) {
+        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, interval));
+
+        ContentException exception = assertThrows(ContentException.class, () -> parser.parse(parametersList));
+        assertEquals(MessageFormat.format(INVALID_HEALTH_CHECK_INTERVAL, interval), exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Introduces the `health-check-interval` MTA module parameter for liveness health checks on CF apps deployed via MTA, achieving feature parity with the underlying Cloud Foundry capability now exposed by the upgraded CF Java client.

Example usage in `mta.yaml`:

```yaml
modules:
  - name: my-app
    type: application
    parameters:
      health-check-interval: 15
```

## Changes

End-to-end wiring of the new parameter:

- `SupportedParameters` — adds `HEALTH_CHECK_INTERVAL` constant to `MODULE_PARAMETERS`.
- `Messages` — adds `INVALID_HEALTH_CHECK_INTERVAL` validation message.
- `StagingParametersParser` — parses, validates (must be > 0, throws `ContentException` otherwise), and forwards the value to `ImmutableStaging`.
- `Staging` interface and `CloudProcess` — adds `getHealthCheckInterval()` accessor (Immutables regenerates the implementations).
- `RawCloudProcess` — maps `Data.getInterval()` from the CF API response into `CloudProcess`.
- `HealthCheckInfo` — adds the `interval` field, getter, and includes it in `equals` so change detection notices interval drifts.
- `CloudControllerRestClientImpl` — forwards the interval to the `Data` builder; widens the `updateApplicationProcess` guard to also fire when only the interval changed; guards `buildHealthCheck` against `HealthCheckType.from(null)` NPE.

## Tests

- `StagingParametersParserTest` — three new tests (correct parse with interval=15, validation rejection with interval=0, null when absent), plus a parameterized test covering positive interval values (1, 15, 60, `Integer.MAX_VALUE`).
- `HealthCheckInfoTest` — four tests covering equal instances, different intervals, null-vs-non-null, and `fromProcess` / `fromStaging` cross-equality.
- `RawCloudProcessTest` — new test class covering `RawCloudProcess.derive()` mapping including health-check interval propagation from the CF API response.

## Jira

JIRA: LMCROSSITXSADEPLOY-3316 — Introduce Health check interval

## Test plan

- [ ] `mvn clean test -pl multiapps-controller-client,multiapps-controller-core` passes locally.
- [ ] Deploy a sample MTA with `health-check-interval: 15` and confirm the CF app's process reports the interval via `cf curl` against the v3 process endpoint.
- [ ] Update an existing MTA's `health-check-interval` and confirm the controller detects the drift and issues an update (rather than a no-op).
- [ ] Negative case: deploy with `health-check-interval: 0` and confirm `ContentException` with `INVALID_HEALTH_CHECK_INTERVAL`.
