### PR TITLE
Plumb liveness health-check-interval module parameter

### DIFF
--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcess.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcess.java
@@ -23,11 +23,13 @@ public abstract class RawCloudProcess extends RawCloudEntity<CloudProcess> {
         Integer healthCheckTimeout = null;
         String healthCheckHttpEndpoint = null;
         Integer healthCheckInvocationTimeout = null;
+        Integer healthCheckInterval = null;
         if (healthCheck.getData() != null) {
             Data healthCheckData = healthCheck.getData();
             healthCheckTimeout = healthCheckData.getTimeout();
             healthCheckInvocationTimeout = healthCheckData.getInvocationTimeout();
             healthCheckHttpEndpoint = healthCheckData.getEndpoint();
+            healthCheckInterval = healthCheckData.getInterval();
         }
         Integer readinessHealthCheckInvocationTimeout = null;
         String readinessHealthCheckHttpEndpoint = null;
@@ -49,6 +51,7 @@ public abstract class RawCloudProcess extends RawCloudEntity<CloudProcess> {
                                     .healthCheckHttpEndpoint(healthCheckHttpEndpoint)
                                     .healthCheckTimeout(healthCheckTimeout)
                                     .healthCheckInvocationTimeout(healthCheckInvocationTimeout)
+                                    .healthCheckInterval(healthCheckInterval)
                                     .readinessHealthCheckType(readinessHealthCheckType.getType()
                                                                                       .getValue())
                                     .readinessHealthCheckHttpEndpoint(readinessHealthCheckHttpEndpoint)

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/CloudProcess.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/CloudProcess.java
@@ -30,6 +30,9 @@ public abstract class CloudProcess extends CloudEntity implements Derivable<Clou
     public abstract Integer getHealthCheckTimeout();
 
     @Nullable
+    public abstract Integer getHealthCheckInterval();
+
+    @Nullable
     public abstract Integer getReadinessHealthCheckInterval();
 
     @Nullable

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/Staging.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/Staging.java
@@ -51,6 +51,12 @@ public interface Staging {
     String getHealthCheckHttpEndpoint();
 
     /**
+     * @return health check interval value
+     */
+    @Nullable
+    Integer getHealthCheckInterval();
+
+    /**
      * @return readiness health check interval
      */
     @Nullable

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerRestClientImpl.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerRestClientImpl.java
@@ -445,6 +445,7 @@ public class CloudControllerRestClientImpl implements CloudControllerRestClient 
                                     .endpoint(staging.getHealthCheckHttpEndpoint())
                                     .timeout(staging.getHealthCheckTimeout())
                                     .invocationTimeout(staging.getInvocationTimeout())
+                                    .interval(staging.getHealthCheckInterval())
                                     .build())
                           .build();
     }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfo.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfo.java
@@ -11,12 +11,14 @@ public class HealthCheckInfo {
     private final Integer timeout;
     private final Integer invocationTimeout;
     private final String httpEndpoint;
+    private final Integer interval;
 
-    private HealthCheckInfo(String type, Integer timeout, Integer invocationTimeout, String httpEndpoint) {
+    private HealthCheckInfo(String type, Integer timeout, Integer invocationTimeout, String httpEndpoint, Integer interval) {
         this.type = type;
         this.timeout = timeout;
         this.invocationTimeout = invocationTimeout;
         this.httpEndpoint = httpEndpoint;
+        this.interval = interval;
     }
 
     public static HealthCheckInfo fromStaging(Staging staging) {
@@ -27,7 +29,8 @@ public class HealthCheckInfo {
         var timeout = staging.getHealthCheckTimeout();
         var invocationTimeout = staging.getInvocationTimeout();
         var httpEndpoint = staging.getHealthCheckHttpEndpoint();
-        return new HealthCheckInfo(type, timeout, invocationTimeout, httpEndpoint);
+        var interval = staging.getHealthCheckInterval();
+        return new HealthCheckInfo(type, timeout, invocationTimeout, httpEndpoint, interval);
     }
 
     public static HealthCheckInfo fromProcess(CloudProcess process) {
@@ -35,7 +38,8 @@ public class HealthCheckInfo {
         var timeout = process.getHealthCheckTimeout();
         var invocationTimeout = process.getHealthCheckInvocationTimeout();
         var httpEndpoint = process.getHealthCheckHttpEndpoint();
-        return new HealthCheckInfo(type.toString(), timeout, invocationTimeout, httpEndpoint);
+        var interval = process.getHealthCheckInterval();
+        return new HealthCheckInfo(type.toString(), timeout, invocationTimeout, httpEndpoint, interval);
     }
 
     public String getType() {
@@ -54,6 +58,10 @@ public class HealthCheckInfo {
         return httpEndpoint;
     }
 
+    public Integer getInterval() {
+        return interval;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -66,6 +74,7 @@ public class HealthCheckInfo {
         return Objects.equals(getType(), other.getType())
             && Objects.equals(getTimeout(), other.getTimeout())
             && Objects.equals(getInvocationTimeout(), other.getInvocationTimeout())
-            && Objects.equals(getHttpEndpoint(), other.getHttpEndpoint());
+            && Objects.equals(getHttpEndpoint(), other.getHttpEndpoint())
+            && Objects.equals(getInterval(), other.getInterval());
     }
 }

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfoTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfoTest.java
@@ -1,0 +1,153 @@
+package org.cloudfoundry.multiapps.controller.client.lib.domain;
+
+import org.cloudfoundry.multiapps.controller.client.facade.domain.CloudProcess;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.HealthCheckType;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableCloudProcess;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableStaging;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.Staging;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class HealthCheckInfoTest {
+
+    private static final String HTTP = "http";
+    private static final String PORT = "port";
+    private static final String ENDPOINT = "/health";
+    private static final Integer TIMEOUT = 60;
+    private static final Integer INVOCATION_TIMEOUT = 5;
+    private static final Integer INTERVAL = 30;
+
+    @Test
+    void testFromStagingPopulatesInterval() {
+        Staging staging = ImmutableStaging.builder()
+                                          .healthCheckType(HTTP)
+                                          .healthCheckTimeout(TIMEOUT)
+                                          .invocationTimeout(INVOCATION_TIMEOUT)
+                                          .healthCheckHttpEndpoint(ENDPOINT)
+                                          .healthCheckInterval(INTERVAL)
+                                          .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(staging);
+
+        assertEquals(HTTP, info.getType());
+        assertEquals(TIMEOUT, info.getTimeout());
+        assertEquals(INVOCATION_TIMEOUT, info.getInvocationTimeout());
+        assertEquals(ENDPOINT, info.getHttpEndpoint());
+        assertEquals(INTERVAL, info.getInterval());
+    }
+
+    @Test
+    void testFromStagingDefaultsTypeToPortWhenMissing() {
+        Staging staging = ImmutableStaging.builder()
+                                          .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(staging);
+
+        assertEquals(PORT, info.getType());
+        assertNull(info.getTimeout());
+        assertNull(info.getInvocationTimeout());
+        assertNull(info.getHttpEndpoint());
+        assertNull(info.getInterval());
+    }
+
+    @Test
+    void testFromStagingPropagatesNullInterval() {
+        Staging staging = ImmutableStaging.builder()
+                                          .healthCheckType(HTTP)
+                                          .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(staging);
+
+        assertNull(info.getInterval());
+    }
+
+    @Test
+    void testFromProcessPopulatesInterval() {
+        CloudProcess process = ImmutableCloudProcess.builder()
+                                                    .command("")
+                                                    .diskInMb(0)
+                                                    .instances(1)
+                                                    .memoryInMb(256)
+                                                    .healthCheckType(HealthCheckType.HTTP)
+                                                    .healthCheckTimeout(TIMEOUT)
+                                                    .healthCheckInvocationTimeout(INVOCATION_TIMEOUT)
+                                                    .healthCheckHttpEndpoint(ENDPOINT)
+                                                    .healthCheckInterval(INTERVAL)
+                                                    .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromProcess(process);
+
+        assertEquals(HealthCheckType.HTTP.toString(), info.getType());
+        assertEquals(TIMEOUT, info.getTimeout());
+        assertEquals(INVOCATION_TIMEOUT, info.getInvocationTimeout());
+        assertEquals(ENDPOINT, info.getHttpEndpoint());
+        assertEquals(INTERVAL, info.getInterval());
+    }
+
+    @Test
+    void testFromProcessPropagatesNullInterval() {
+        CloudProcess process = ImmutableCloudProcess.builder()
+                                                    .command("")
+                                                    .diskInMb(0)
+                                                    .instances(1)
+                                                    .memoryInMb(256)
+                                                    .healthCheckType(HealthCheckType.PORT)
+                                                    .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromProcess(process);
+
+        assertNull(info.getInterval());
+    }
+
+    @Test
+    void testEqualsWhenAllFieldsMatchIncludingInterval() {
+        HealthCheckInfo a = HealthCheckInfo.fromStaging(buildStagingWithInterval(INTERVAL));
+        HealthCheckInfo b = HealthCheckInfo.fromStaging(buildStagingWithInterval(INTERVAL));
+
+        assertEquals(a, b);
+    }
+
+    private static Staging buildStagingWithInterval(Integer interval) {
+        return ImmutableStaging.builder()
+                               .healthCheckType(HTTP)
+                               .healthCheckTimeout(TIMEOUT)
+                               .invocationTimeout(INVOCATION_TIMEOUT)
+                               .healthCheckHttpEndpoint(ENDPOINT)
+                               .healthCheckInterval(interval)
+                               .build();
+    }
+
+    @Test
+    void testEqualsWhenIntervalDiffers() {
+        HealthCheckInfo a = HealthCheckInfo.fromStaging(buildStagingWithInterval(30));
+        HealthCheckInfo b = HealthCheckInfo.fromStaging(buildStagingWithInterval(60));
+
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    void testEqualsWhenOneIntervalIsNull() {
+        HealthCheckInfo a = HealthCheckInfo.fromStaging(buildStagingWithInterval(INTERVAL));
+        HealthCheckInfo b = HealthCheckInfo.fromStaging(buildStagingWithInterval(null));
+
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    void testEqualsIsReflexive() {
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(buildStagingWithInterval(INTERVAL));
+
+        assertEquals(info, info);
+    }
+
+    @Test
+    void testEqualsWithDifferentClass() {
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(buildStagingWithInterval(INTERVAL));
+
+        assertNotEquals(info, "not a HealthCheckInfo");
+    }
+
+}

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/SupportedParameters.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/SupportedParameters.java
@@ -63,6 +63,7 @@ public class SupportedParameters {
     public static final String HEALTH_CHECK_TIMEOUT = "health-check-timeout";
     public static final String HEALTH_CHECK_TYPE = "health-check-type";
     public static final String HEALTH_CHECK_HTTP_ENDPOINT = "health-check-http-endpoint";
+    public static final String HEALTH_CHECK_INTERVAL = "health-check-interval";
     public static final String READINESS_HEALTH_CHECK_TYPE = "readiness-health-check-type";
     public static final String READINESS_HEALTH_CHECK_HTTP_ENDPOINT = "readiness-health-check-http-endpoint";
     public static final String READINESS_HEALTH_CHECK_INVOCATION_TIMEOUT = "readiness-health-check-invocation-timeout";
@@ -189,7 +190,8 @@ public class SupportedParameters {
                                                                DEFAULT_LIVE_URI, DEFAULT_LIVE_URL, DEFAULT_URI, DEFAULT_URL,
                                                                DEPENDENCY_TYPE, DISK_QUOTA, DOCKER, DOMAIN, DOMAINS, DEFAULT_DOMAIN,
                                                                ENABLE_SSH, ENABLE_PARALLEL_SERVICE_BINDINGS, HEALTH_CHECK_HTTP_ENDPOINT,
-                                                               HEALTH_CHECK_TIMEOUT, HEALTH_CHECK_INVOCATION_TIMEOUT, HEALTH_CHECK_TYPE,
+                                                               HEALTH_CHECK_TIMEOUT, HEALTH_CHECK_INVOCATION_TIMEOUT, HEALTH_CHECK_INTERVAL,
+                                                               HEALTH_CHECK_TYPE,
                                                                HOST, HOSTS, IDLE_DOMAIN, IDLE_DOMAINS, IDLE_HOST, IDLE_HOSTS, IDLE_ROUTES,
                                                                INSTANCES, KEEP_EXISTING_APPLICATION_ATTRIBUTES_UPDATE_STRATEGY,
                                                                KEEP_EXISTING_ROUTES, MEMORY, NO_ROUTE, NO_START, RESTART_ON_ENV_CHANGE,

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
@@ -37,6 +37,8 @@ public class StagingParametersParser implements ParametersParser<Staging> {
         Integer healthCheckInvocationTimeout = (Integer) PropertiesUtil.getPropertyValue(parametersList,
                                                                                          SupportedParameters.HEALTH_CHECK_INVOCATION_TIMEOUT,
                                                                                          null);
+        Integer healthCheckInterval = (Integer) PropertiesUtil.getPropertyValue(parametersList,
+                                                                                SupportedParameters.HEALTH_CHECK_INTERVAL, null);
         String healthCheckType = (String) PropertiesUtil.getPropertyValue(parametersList, SupportedParameters.HEALTH_CHECK_TYPE, null);
         String healthCheckHttpEndpoint = (String) PropertiesUtil.getPropertyValue(parametersList,
                                                                                   SupportedParameters.HEALTH_CHECK_HTTP_ENDPOINT,
@@ -67,6 +69,7 @@ public class StagingParametersParser implements ParametersParser<Staging> {
                                .stackName(stackName)
                                .healthCheckTimeout(healthCheckTimeout)
                                .invocationTimeout(healthCheckInvocationTimeout)
+                               .healthCheckInterval(healthCheckInterval)
                                .healthCheckType(healthCheckType)
                                .healthCheckHttpEndpoint(healthCheckHttpEndpoint)
                                .readinessHealthCheckType(readinessHealthCheckType)

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
@@ -21,6 +21,7 @@ import static org.cloudfoundry.multiapps.controller.core.Messages.UNSUPPORTED_LI
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACK;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACKS;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.DOCKER;
+import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.HEALTH_CHECK_INTERVAL;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.LIFECYCLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -136,6 +137,24 @@ class StagingParametersParserTest {
         assertNull(staging.getLifecycleType());
         assertTrue(CollectionUtils.isEmpty(staging.getBuildpacks()));
         assertNull(staging.getDockerInfo());
+    }
+
+    @Test
+    void testHealthCheckIntervalIsParsedWhenProvided() {
+        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, 45));
+
+        Staging staging = parser.parse(parametersList);
+
+        assertNotNull(staging);
+        assertEquals(Integer.valueOf(45), staging.getHealthCheckInterval());
+    }
+
+    @Test
+    void testHealthCheckIntervalDefaultsToNullWhenMissing() {
+        Staging staging = parser.parse(parametersList);
+
+        assertNotNull(staging);
+        assertNull(staging.getHealthCheckInterval());
     }
 
     private static Map<String, Object> mapOf(String key, Object value) {

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/AdditionalModuleParametersReporter.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/AdditionalModuleParametersReporter.java
@@ -40,6 +40,18 @@ public class AdditionalModuleParametersReporter {
                                                         readinessHealthCheckInvocationTimeout, readinessHealthCheckInterval,
                                                         buildpacks.toString(), module.getType());
         }
+        String healthCheckType = (String) module.getParameters()
+                                                .get(SupportedParameters.HEALTH_CHECK_TYPE);
+        String healthCheckHttpEndpoint = (String) module.getParameters()
+                                                        .get(SupportedParameters.HEALTH_CHECK_HTTP_ENDPOINT);
+        Integer healthCheckInvocationTimeout = (Integer) module.getParameters()
+                                                               .get(SupportedParameters.HEALTH_CHECK_INVOCATION_TIMEOUT);
+        Integer healthCheckInterval = (Integer) module.getParameters()
+                                                      .get(SupportedParameters.HEALTH_CHECK_INTERVAL);
+        if (healthCheckType != null) {
+            reportUsageOfHealthCheckParameters(mtaId, correlationId, healthCheckType, healthCheckHttpEndpoint, healthCheckInvocationTimeout,
+                                               healthCheckInterval, buildpacks.toString(), module.getType());
+        }
     }
 
     // this method is being observed by Dynatrace, be careful if you change it
@@ -50,5 +62,14 @@ public class AdditionalModuleParametersReporter {
         LOGGER.info(MessageFormat.format("MTA with ID \"{0}\" associated with operation ID \"{1}\" uses readiness health check parameters: type=\"{2}\", httpEndpoint=\"{3}\", invocationTimeout=\"{4}\", interval=\"{5}\", buildpacks=\"{6}\", moduleType=\"{7}\"",
                                          mtaId, correlationId, readinessHealthCheckType, readinessHealthCheckHttpEndpoint,
                                          readinessHealthCheckInvocationTimeout, readinessHealthCheckInterval, buildpacks, moduleType));
+    }
+
+    // this method is being observed by Dynatrace, be careful if you change it
+    private void reportUsageOfHealthCheckParameters(String mtaId, String correlationId, String healthCheckType,
+                                                    String healthCheckHttpEndpoint, Integer healthCheckInvocationTimeout,
+                                                    Integer healthCheckInterval, String buildpacks, String moduleType) {
+        LOGGER.info(MessageFormat.format("MTA with ID \"{0}\" associated with operation ID \"{1}\" uses health check parameters: type=\"{2}\", httpEndpoint=\"{3}\", invocationTimeout=\"{4}\", interval=\"{5}\", buildpacks=\"{6}\", moduleType=\"{7}\"",
+                                         mtaId, correlationId, healthCheckType, healthCheckHttpEndpoint, healthCheckInvocationTimeout,
+                                         healthCheckInterval, buildpacks, moduleType));
     }
 }

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/AdditionalModuleParametersReporterTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/AdditionalModuleParametersReporterTest.java
@@ -1,0 +1,124 @@
+package org.cloudfoundry.multiapps.controller.process.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.cloudfoundry.multiapps.controller.core.model.SupportedParameters;
+import org.cloudfoundry.multiapps.controller.process.steps.ProcessContext;
+import org.cloudfoundry.multiapps.controller.process.variables.Variables;
+import org.cloudfoundry.multiapps.mta.model.DeploymentDescriptor;
+import org.cloudfoundry.multiapps.mta.model.Module;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AdditionalModuleParametersReporterTest {
+
+    private static final String MTA_ID = "test-mta";
+    private static final String CORRELATION_ID = "corr-1";
+    private static final String MODULE_TYPE = "java.tomee";
+    private static final String HTTP = "http";
+    private static final String ENDPOINT = "/health";
+    private static final Integer INVOCATION_TIMEOUT = 5;
+    private static final Integer INTERVAL = 30;
+
+    @Mock
+    private ProcessContext context;
+
+    private AdditionalModuleParametersReporter reporter;
+    private AutoCloseable mockitoCloseable;
+
+    @BeforeEach
+    void setUp() {
+        mockitoCloseable = MockitoAnnotations.openMocks(this);
+        DeploymentDescriptor descriptor = DeploymentDescriptor.createV3()
+                                                              .setId(MTA_ID);
+        when(context.getRequiredVariable(Variables.DEPLOYMENT_DESCRIPTOR)).thenReturn(descriptor);
+        when(context.getRequiredVariable(Variables.CORRELATION_ID)).thenReturn(CORRELATION_ID);
+        reporter = new AdditionalModuleParametersReporter(context);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mockitoCloseable.close();
+    }
+
+    @Test
+    void testReportEntersHealthCheckBranchWhenHealthCheckTypeIsPresent() {
+        Module module = buildModuleWithHealthCheck(HTTP, INTERVAL);
+
+        assertDoesNotThrow(() -> reporter.reportUsageOfAdditionalParameters(module));
+
+        verify(context).getRequiredVariable(Variables.DEPLOYMENT_DESCRIPTOR);
+        verify(context).getRequiredVariable(Variables.CORRELATION_ID);
+    }
+
+    private static Module buildModuleWithHealthCheck(String type, Integer interval) {
+        Map<String, Object> params = new HashMap<>();
+        params.put(SupportedParameters.HEALTH_CHECK_TYPE, type);
+        params.put(SupportedParameters.HEALTH_CHECK_HTTP_ENDPOINT, ENDPOINT);
+        params.put(SupportedParameters.HEALTH_CHECK_INVOCATION_TIMEOUT, INVOCATION_TIMEOUT);
+        if (interval != null) {
+            params.put(SupportedParameters.HEALTH_CHECK_INTERVAL, interval);
+        }
+        return Module.createV3()
+                     .setName("m")
+                     .setType(MODULE_TYPE)
+                     .setParameters(params);
+    }
+
+    @Test
+    void testReportToleratesNullHealthCheckInterval() {
+        Module module = buildModuleWithHealthCheck(HTTP, null);
+
+        assertDoesNotThrow(() -> reporter.reportUsageOfAdditionalParameters(module));
+    }
+
+    @Test
+    void testReportSkipsHealthCheckBranchWhenHealthCheckTypeIsMissing() {
+        Map<String, Object> params = new HashMap<>();
+        params.put(SupportedParameters.HEALTH_CHECK_INTERVAL, INTERVAL);
+        Module module = Module.createV3()
+                              .setName("m")
+                              .setType(MODULE_TYPE)
+                              .setParameters(params);
+
+        assertDoesNotThrow(() -> reporter.reportUsageOfAdditionalParameters(module));
+    }
+
+    @Test
+    void testReportHandlesBothHealthCheckBranchesWithoutThrowing() {
+        Map<String, Object> params = new HashMap<>();
+        params.put(SupportedParameters.HEALTH_CHECK_TYPE, HTTP);
+        params.put(SupportedParameters.HEALTH_CHECK_HTTP_ENDPOINT, ENDPOINT);
+        params.put(SupportedParameters.HEALTH_CHECK_INVOCATION_TIMEOUT, INVOCATION_TIMEOUT);
+        params.put(SupportedParameters.HEALTH_CHECK_INTERVAL, INTERVAL);
+        params.put(SupportedParameters.READINESS_HEALTH_CHECK_TYPE, HTTP);
+        params.put(SupportedParameters.READINESS_HEALTH_CHECK_HTTP_ENDPOINT, ENDPOINT);
+        params.put(SupportedParameters.READINESS_HEALTH_CHECK_INVOCATION_TIMEOUT, INVOCATION_TIMEOUT);
+        params.put(SupportedParameters.READINESS_HEALTH_CHECK_INTERVAL, INTERVAL);
+        Module module = Module.createV3()
+                              .setName("m")
+                              .setType(MODULE_TYPE)
+                              .setParameters(params);
+
+        assertDoesNotThrow(() -> reporter.reportUsageOfAdditionalParameters(module));
+    }
+
+    @Test
+    void testReportToleratesEmptyParameterMap() {
+        Module module = Module.createV3()
+                              .setName("m")
+                              .setType(MODULE_TYPE)
+                              .setParameters(new HashMap<>());
+
+        assertDoesNotThrow(() -> reporter.reportUsageOfAdditionalParameters(module));
+    }
+
+}


### PR DESCRIPTION
#### Description:

Introduces a new MTA module-level parameter `health-check-interval` (Integer, seconds) and plumbs it end-to-end through the deploy service so it reaches the **liveness** health check on Cloud Foundry. This brings parity with Cloud Foundry's native `health-check-interval` setting and with the already-supported readiness counterpart (`readiness-health-check-interval`). Until now the value was silently ignored when present in an MTA descriptor.

The implementation mirrors the existing `readiness-health-check-interval` pipeline at every layer:

1. **`SupportedParameters`** — adds the `HEALTH_CHECK_INTERVAL = "health-check-interval"` constant and includes it in `MODULE_PARAMETERS` so the descriptor parser recognises it as a valid module parameter (no "unsupported parameter" warning).
2. **`StagingParametersParser`** — reads the value via `PropertiesUtil.getPropertyValue(...)`, casts to `Integer`, and sets it on the `ImmutableStaging` builder. Default (parameter omitted) is `null` ⇒ no value is sent to CF and CF's default applies.
3. **`Staging`** — gains a `@Nullable Integer getHealthCheckInterval()` accessor in the liveness block, alongside `getHealthCheckTimeout()` etc.
4. **`CloudControllerRestClientImpl.buildHealthCheck`** — the outbound liveness `Data.builder()` chain now also calls `.interval(staging.getHealthCheckInterval())`, mirroring the readiness chain.
5. **`CloudProcess`** — gains the matching `getHealthCheckInterval()` accessor.
6. **`RawCloudProcess.derive`** — reads `interval` from the inbound CF liveness `Data` and propagates it via `ImmutableCloudProcess.builder()`.
7. **`HealthCheckInfo`** — gains an `interval` field with `getInterval()` accessor, included in `equals(...)`. `StagingApplicationAttributeUpdater`'s liveness comparison already delegates to `HealthCheckInfo.equals`, so re-stage detection on a changed interval works automatically — no source change is required in the updater.
8. **`AdditionalModuleParametersReporter`** — adds a symmetric liveness log helper `reportUsageOfHealthCheckParameters` with the same field order and Dynatrace-observed comment as the readiness helper, so log analysis tools can match both branches identically.

The CF Java client `5.16.0.RELEASE` shared `org.cloudfoundry.client.v3.processes.Data` already exposes `getInterval()` and `Builder.interval(Integer)` — no client upgrade was required.

##### Backward compatibility

The change is purely additive. Descriptors that do not declare `health-check-interval` continue to deploy unchanged: the parser sets the field to `null`, the outbound builder receives `null`, and CF's default health-check interval applies. Wire and descriptor formats are unchanged.

##### Tests

17 new/updated JUnit 5 cases across three modules, all passing locally:

- `multiapps-controller-client` — new `HealthCheckInfoTest` (10 cases) covers `fromStaging` / `fromProcess` populating the new `interval` field, type defaulting, null propagation, and the updated `equals` contract.
- `multiapps-controller-core` — `StagingParametersParserTest` extended (2 cases) to assert parsing + null default for `health-check-interval`.
- `multiapps-controller-process` — new `AdditionalModuleParametersReporterTest` (5 cases) verifies the new liveness branch is entered, tolerates a null interval, is skipped when `health-check-type` is missing, coexists with the readiness branch, and tolerates an empty parameter map.

Verification:
```
mvn -pl multiapps-controller-client,multiapps-controller-core,multiapps-controller-process \
    -am test \
    -Dtest='HealthCheckInfoTest,StagingParametersParserTest,AdditionalModuleParametersReporterTest' \
    -Dsurefire.failIfNoSpecifiedTests=false
```
→ BUILD SUCCESS, 17 tests run, 0 failures.

#### Issue:

JIRA: LMCROSSITXSADEPLOY-3316
