### PR TITLE
Introduce health-check-interval parameter for liveness probe

### DIFF
--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcess.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcess.java
@@ -23,11 +23,13 @@ public abstract class RawCloudProcess extends RawCloudEntity<CloudProcess> {
         Integer healthCheckTimeout = null;
         String healthCheckHttpEndpoint = null;
         Integer healthCheckInvocationTimeout = null;
+        Integer healthCheckInterval = null;
         if (healthCheck.getData() != null) {
             Data healthCheckData = healthCheck.getData();
             healthCheckTimeout = healthCheckData.getTimeout();
             healthCheckInvocationTimeout = healthCheckData.getInvocationTimeout();
             healthCheckHttpEndpoint = healthCheckData.getEndpoint();
+            healthCheckInterval = healthCheckData.getInterval();
         }
         Integer readinessHealthCheckInvocationTimeout = null;
         String readinessHealthCheckHttpEndpoint = null;
@@ -49,6 +51,7 @@ public abstract class RawCloudProcess extends RawCloudEntity<CloudProcess> {
                                     .healthCheckHttpEndpoint(healthCheckHttpEndpoint)
                                     .healthCheckTimeout(healthCheckTimeout)
                                     .healthCheckInvocationTimeout(healthCheckInvocationTimeout)
+                                    .healthCheckInterval(healthCheckInterval)
                                     .readinessHealthCheckType(readinessHealthCheckType.getType()
                                                                                       .getValue())
                                     .readinessHealthCheckHttpEndpoint(readinessHealthCheckHttpEndpoint)

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/CloudProcess.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/CloudProcess.java
@@ -30,6 +30,9 @@ public abstract class CloudProcess extends CloudEntity implements Derivable<Clou
     public abstract Integer getHealthCheckTimeout();
 
     @Nullable
+    public abstract Integer getHealthCheckInterval();
+
+    @Nullable
     public abstract Integer getReadinessHealthCheckInterval();
 
     @Nullable

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/Staging.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/Staging.java
@@ -51,6 +51,12 @@ public interface Staging {
     String getHealthCheckHttpEndpoint();
 
     /**
+     * @return liveness health check interval
+     */
+    @Nullable
+    Integer getHealthCheckInterval();
+
+    /**
      * @return readiness health check interval
      */
     @Nullable

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerRestClientImpl.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerRestClientImpl.java
@@ -445,6 +445,7 @@ public class CloudControllerRestClientImpl implements CloudControllerRestClient 
                                     .endpoint(staging.getHealthCheckHttpEndpoint())
                                     .timeout(staging.getHealthCheckTimeout())
                                     .invocationTimeout(staging.getInvocationTimeout())
+                                    .interval(staging.getHealthCheckInterval())
                                     .build())
                           .build();
     }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfo.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfo.java
@@ -10,12 +10,14 @@ public class HealthCheckInfo {
     private final String type;
     private final Integer timeout;
     private final Integer invocationTimeout;
+    private final Integer interval;
     private final String httpEndpoint;
 
-    private HealthCheckInfo(String type, Integer timeout, Integer invocationTimeout, String httpEndpoint) {
+    private HealthCheckInfo(String type, Integer timeout, Integer invocationTimeout, Integer interval, String httpEndpoint) {
         this.type = type;
         this.timeout = timeout;
         this.invocationTimeout = invocationTimeout;
+        this.interval = interval;
         this.httpEndpoint = httpEndpoint;
     }
 
@@ -26,16 +28,18 @@ public class HealthCheckInfo {
         }
         var timeout = staging.getHealthCheckTimeout();
         var invocationTimeout = staging.getInvocationTimeout();
+        var interval = staging.getHealthCheckInterval();
         var httpEndpoint = staging.getHealthCheckHttpEndpoint();
-        return new HealthCheckInfo(type, timeout, invocationTimeout, httpEndpoint);
+        return new HealthCheckInfo(type, timeout, invocationTimeout, interval, httpEndpoint);
     }
 
     public static HealthCheckInfo fromProcess(CloudProcess process) {
         var type = process.getHealthCheckType();
         var timeout = process.getHealthCheckTimeout();
         var invocationTimeout = process.getHealthCheckInvocationTimeout();
+        var interval = process.getHealthCheckInterval();
         var httpEndpoint = process.getHealthCheckHttpEndpoint();
-        return new HealthCheckInfo(type.toString(), timeout, invocationTimeout, httpEndpoint);
+        return new HealthCheckInfo(type.toString(), timeout, invocationTimeout, interval, httpEndpoint);
     }
 
     public String getType() {
@@ -48,6 +52,10 @@ public class HealthCheckInfo {
 
     public Integer getInvocationTimeout() {
         return invocationTimeout;
+    }
+
+    public Integer getInterval() {
+        return interval;
     }
 
     public String getHttpEndpoint() {
@@ -66,6 +74,7 @@ public class HealthCheckInfo {
         return Objects.equals(getType(), other.getType())
             && Objects.equals(getTimeout(), other.getTimeout())
             && Objects.equals(getInvocationTimeout(), other.getInvocationTimeout())
+            && Objects.equals(getInterval(), other.getInterval())
             && Objects.equals(getHttpEndpoint(), other.getHttpEndpoint());
     }
 }

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcessTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcessTest.java
@@ -1,0 +1,84 @@
+package org.cloudfoundry.multiapps.controller.client.facade.adapters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.cloudfoundry.client.v3.processes.Data;
+import org.cloudfoundry.client.v3.processes.HealthCheck;
+import org.cloudfoundry.client.v3.processes.HealthCheckType;
+import org.cloudfoundry.client.v3.processes.Process;
+import org.cloudfoundry.client.v3.processes.ReadinessHealthCheck;
+import org.cloudfoundry.client.v3.processes.ReadinessHealthCheckType;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.CloudProcess;
+import org.junit.jupiter.api.Test;
+
+class RawCloudProcessTest {
+
+    @Test
+    void testDeriveCarriesLivenessIntervalFromHealthCheckData() {
+        Process process = buildProcess(buildHealthCheck(15), buildReadinessHealthCheck(null));
+
+        CloudProcess derived = ImmutableRawCloudProcess.of(process)
+                                                       .derive();
+
+        assertEquals(15, derived.getHealthCheckInterval());
+    }
+
+    @Test
+    void testDeriveLivenessIntervalIsNullWhenAbsent() {
+        Process process = buildProcess(buildHealthCheck(null), buildReadinessHealthCheck(null));
+
+        CloudProcess derived = ImmutableRawCloudProcess.of(process)
+                                                       .derive();
+
+        assertNull(derived.getHealthCheckInterval());
+    }
+
+    @Test
+    void testDeriveLivenessIntervalIsNullWhenHealthCheckDataIsNull() {
+        HealthCheck healthCheck = mock(HealthCheck.class);
+        when(healthCheck.getData()).thenReturn(null);
+        when(healthCheck.getType()).thenReturn(HealthCheckType.PORT);
+        Process process = buildProcess(healthCheck, buildReadinessHealthCheck(null));
+
+        CloudProcess derived = ImmutableRawCloudProcess.of(process)
+                                                       .derive();
+
+        assertNull(derived.getHealthCheckInterval());
+    }
+
+    private static Process buildProcess(HealthCheck healthCheck, ReadinessHealthCheck readinessHealthCheck) {
+        Process process = mock(Process.class);
+        when(process.getCommand()).thenReturn("test-command");
+        when(process.getInstances()).thenReturn(1);
+        when(process.getMemoryInMb()).thenReturn(256);
+        when(process.getDiskInMb()).thenReturn(512);
+        when(process.getHealthCheck()).thenReturn(healthCheck);
+        when(process.getReadinessHealthCheck()).thenReturn(readinessHealthCheck);
+        return process;
+    }
+
+    private static HealthCheck buildHealthCheck(Integer interval) {
+        Data.Builder dataBuilder = Data.builder();
+        if (interval != null) {
+            dataBuilder.interval(interval);
+        }
+        return HealthCheck.builder()
+                          .type(HealthCheckType.PORT)
+                          .data(dataBuilder.build())
+                          .build();
+    }
+
+    private static ReadinessHealthCheck buildReadinessHealthCheck(Integer interval) {
+        Data.Builder dataBuilder = Data.builder();
+        if (interval != null) {
+            dataBuilder.interval(interval);
+        }
+        return ReadinessHealthCheck.builder()
+                                   .type(ReadinessHealthCheckType.PORT)
+                                   .data(dataBuilder.build())
+                                   .build();
+    }
+}

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfoTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfoTest.java
@@ -1,0 +1,142 @@
+package org.cloudfoundry.multiapps.controller.client.lib.domain;
+
+import org.cloudfoundry.multiapps.controller.client.facade.domain.CloudProcess;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.HealthCheckType;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableCloudProcess;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableStaging;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.Staging;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class HealthCheckInfoTest {
+
+    @Test
+    void testFromStagingCarriesInterval() {
+        Staging staging = ImmutableStaging.builder()
+                                          .healthCheckType("http")
+                                          .healthCheckTimeout(30)
+                                          .invocationTimeout(5)
+                                          .healthCheckInterval(15)
+                                          .healthCheckHttpEndpoint("/health")
+                                          .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(staging);
+
+        assertEquals("http", info.getType());
+        assertEquals(30, info.getTimeout());
+        assertEquals(5, info.getInvocationTimeout());
+        assertEquals(15, info.getInterval());
+        assertEquals("/health", info.getHttpEndpoint());
+    }
+
+    @Test
+    void testFromStagingIntervalIsNullWhenAbsent() {
+        Staging staging = ImmutableStaging.builder()
+                                          .healthCheckType("port")
+                                          .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(staging);
+
+        assertNull(info.getInterval());
+    }
+
+    @Test
+    void testFromStagingDefaultsTypeToPortWhenNull() {
+        Staging staging = ImmutableStaging.builder()
+                                          .healthCheckInterval(10)
+                                          .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(staging);
+
+        assertEquals("port", info.getType());
+        assertEquals(10, info.getInterval());
+    }
+
+    @Test
+    void testFromProcessCarriesInterval() {
+        CloudProcess process = ImmutableCloudProcess.builder()
+                                                    .command("test-cmd")
+                                                    .diskInMb(512)
+                                                    .instances(1)
+                                                    .memoryInMb(256)
+                                                    .healthCheckType(HealthCheckType.HTTP)
+                                                    .healthCheckTimeout(45)
+                                                    .healthCheckInvocationTimeout(7)
+                                                    .healthCheckInterval(20)
+                                                    .healthCheckHttpEndpoint("/live")
+                                                    .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromProcess(process);
+
+        assertEquals("http", info.getType());
+        assertEquals(45, info.getTimeout());
+        assertEquals(7, info.getInvocationTimeout());
+        assertEquals(20, info.getInterval());
+        assertEquals("/live", info.getHttpEndpoint());
+    }
+
+    @Test
+    void testFromProcessIntervalIsNullWhenAbsent() {
+        CloudProcess process = ImmutableCloudProcess.builder()
+                                                    .command("test-cmd")
+                                                    .diskInMb(512)
+                                                    .instances(1)
+                                                    .memoryInMb(256)
+                                                    .healthCheckType(HealthCheckType.PORT)
+                                                    .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromProcess(process);
+
+        assertNull(info.getInterval());
+    }
+
+    @Test
+    void testEqualsReturnsFalseWhenIntervalDiffers() {
+        Staging stagingA = ImmutableStaging.builder()
+                                           .healthCheckType("port")
+                                           .healthCheckInterval(10)
+                                           .build();
+        Staging stagingB = ImmutableStaging.builder()
+                                           .healthCheckType("port")
+                                           .healthCheckInterval(20)
+                                           .build();
+
+        assertNotEquals(HealthCheckInfo.fromStaging(stagingA), HealthCheckInfo.fromStaging(stagingB));
+    }
+
+    @Test
+    void testEqualsReturnsTrueWhenAllFieldsMatchIncludingInterval() {
+        Staging stagingA = ImmutableStaging.builder()
+                                           .healthCheckType("port")
+                                           .healthCheckTimeout(30)
+                                           .invocationTimeout(5)
+                                           .healthCheckInterval(10)
+                                           .healthCheckHttpEndpoint("/health")
+                                           .build();
+        Staging stagingB = ImmutableStaging.builder()
+                                           .healthCheckType("port")
+                                           .healthCheckTimeout(30)
+                                           .invocationTimeout(5)
+                                           .healthCheckInterval(10)
+                                           .healthCheckHttpEndpoint("/health")
+                                           .build();
+
+        assertEquals(HealthCheckInfo.fromStaging(stagingA), HealthCheckInfo.fromStaging(stagingB));
+    }
+
+    @Test
+    void testEqualsReturnsFalseWhenOneIntervalIsNull() {
+        Staging stagingWithInterval = ImmutableStaging.builder()
+                                                      .healthCheckType("port")
+                                                      .healthCheckInterval(10)
+                                                      .build();
+        Staging stagingWithoutInterval = ImmutableStaging.builder()
+                                                         .healthCheckType("port")
+                                                         .build();
+
+        assertNotEquals(HealthCheckInfo.fromStaging(stagingWithInterval), HealthCheckInfo.fromStaging(stagingWithoutInterval));
+    }
+}

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Messages.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Messages.java
@@ -91,6 +91,7 @@ public final class Messages {
     public static final String BUILDPACKS_REQUIRED_FOR_CNB = "Buildpacks must be provided when lifecycle is set to 'cnb'.";
     public static final String DOCKER_INFO_REQUIRED = "Docker information must be provided when lifecycle is set to 'docker'.";
     public static final String BUILDPACKS_NOT_ALLOWED_WITH_DOCKER = "Buildpacks must not be provided when lifecycle is set to 'docker'.";
+    public static final String INVALID_HEALTH_CHECK_INTERVAL = "Invalid value \"{0}\" for parameter \"health-check-interval\". The value must be a positive integer (seconds).";
     public static final String EXTENSION_DESCRIPTORS_COULD_NOT_BE_PARSED_TO_VALID_YAML = "Extension descriptor(s) could not be parsed as a valid YAML file. These descriptors may fail future deployments once stricter validation is enforced. Please review and correct them now to avoid future issues. Use at your own risk";
     public static final String UNSUPPORTED_FILE_FORMAT = "Unsupported file format! \"{0}\" detected";
     public static final String ENCRYPTION_HAS_FAILED = "Encryption has failed! Errored with \"{0}\"";

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Messages.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Messages.java
@@ -91,7 +91,6 @@ public final class Messages {
     public static final String BUILDPACKS_REQUIRED_FOR_CNB = "Buildpacks must be provided when lifecycle is set to 'cnb'.";
     public static final String DOCKER_INFO_REQUIRED = "Docker information must be provided when lifecycle is set to 'docker'.";
     public static final String BUILDPACKS_NOT_ALLOWED_WITH_DOCKER = "Buildpacks must not be provided when lifecycle is set to 'docker'.";
-    public static final String INVALID_HEALTH_CHECK_INTERVAL = "Invalid value \"{0}\" for parameter \"health-check-interval\". The value must be a positive integer (seconds).";
     public static final String EXTENSION_DESCRIPTORS_COULD_NOT_BE_PARSED_TO_VALID_YAML = "Extension descriptor(s) could not be parsed as a valid YAML file. These descriptors may fail future deployments once stricter validation is enforced. Please review and correct them now to avoid future issues. Use at your own risk";
     public static final String UNSUPPORTED_FILE_FORMAT = "Unsupported file format! \"{0}\" detected";
     public static final String ENCRYPTION_HAS_FAILED = "Encryption has failed! Errored with \"{0}\"";

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/SupportedParameters.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/SupportedParameters.java
@@ -63,6 +63,7 @@ public class SupportedParameters {
     public static final String HEALTH_CHECK_TIMEOUT = "health-check-timeout";
     public static final String HEALTH_CHECK_TYPE = "health-check-type";
     public static final String HEALTH_CHECK_HTTP_ENDPOINT = "health-check-http-endpoint";
+    public static final String HEALTH_CHECK_INTERVAL = "health-check-interval";
     public static final String READINESS_HEALTH_CHECK_TYPE = "readiness-health-check-type";
     public static final String READINESS_HEALTH_CHECK_HTTP_ENDPOINT = "readiness-health-check-http-endpoint";
     public static final String READINESS_HEALTH_CHECK_INVOCATION_TIMEOUT = "readiness-health-check-invocation-timeout";
@@ -190,6 +191,7 @@ public class SupportedParameters {
                                                                DEPENDENCY_TYPE, DISK_QUOTA, DOCKER, DOMAIN, DOMAINS, DEFAULT_DOMAIN,
                                                                ENABLE_SSH, ENABLE_PARALLEL_SERVICE_BINDINGS, HEALTH_CHECK_HTTP_ENDPOINT,
                                                                HEALTH_CHECK_TIMEOUT, HEALTH_CHECK_INVOCATION_TIMEOUT, HEALTH_CHECK_TYPE,
+                                                               HEALTH_CHECK_INTERVAL,
                                                                HOST, HOSTS, IDLE_DOMAIN, IDLE_DOMAINS, IDLE_HOST, IDLE_HOSTS, IDLE_ROUTES,
                                                                INSTANCES, KEEP_EXISTING_APPLICATION_ATTRIBUTES_UPDATE_STRATEGY,
                                                                KEEP_EXISTING_ROUTES, MEMORY, NO_ROUTE, NO_START, RESTART_ON_ENV_CHANGE,

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
@@ -20,7 +20,6 @@ import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_NOT
 import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_REQUIRED_FOR_CNB;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_NOT_ALLOWED_WITH_LIFECYCLE;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_REQUIRED;
-import static org.cloudfoundry.multiapps.controller.core.Messages.INVALID_HEALTH_CHECK_INTERVAL;
 import static org.cloudfoundry.multiapps.controller.core.Messages.UNSUPPORTED_LIFECYCLE_VALUE;
 
 public class StagingParametersParser implements ParametersParser<Staging> {
@@ -40,7 +39,6 @@ public class StagingParametersParser implements ParametersParser<Staging> {
                                                                                          null);
         Integer healthCheckInterval = (Integer) PropertiesUtil.getPropertyValue(parametersList,
                                                                                 SupportedParameters.HEALTH_CHECK_INTERVAL, null);
-        validateHealthCheckInterval(healthCheckInterval);
         String healthCheckType = (String) PropertiesUtil.getPropertyValue(parametersList, SupportedParameters.HEALTH_CHECK_TYPE, null);
         String healthCheckHttpEndpoint = (String) PropertiesUtil.getPropertyValue(parametersList,
                                                                                   SupportedParameters.HEALTH_CHECK_HTTP_ENDPOINT,
@@ -83,12 +81,6 @@ public class StagingParametersParser implements ParametersParser<Staging> {
                                .dockerInfo(dockerInfo)
                                .lifecycleType(lifecycleType)
                                .build();
-    }
-
-    private void validateHealthCheckInterval(Integer healthCheckInterval) {
-        if (healthCheckInterval != null && healthCheckInterval <= 0) {
-            throw new ContentException(MessageFormat.format(INVALID_HEALTH_CHECK_INTERVAL, healthCheckInterval));
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
@@ -37,6 +37,8 @@ public class StagingParametersParser implements ParametersParser<Staging> {
         Integer healthCheckInvocationTimeout = (Integer) PropertiesUtil.getPropertyValue(parametersList,
                                                                                          SupportedParameters.HEALTH_CHECK_INVOCATION_TIMEOUT,
                                                                                          null);
+        Integer healthCheckInterval = (Integer) PropertiesUtil.getPropertyValue(parametersList,
+                                                                                SupportedParameters.HEALTH_CHECK_INTERVAL, null);
         String healthCheckType = (String) PropertiesUtil.getPropertyValue(parametersList, SupportedParameters.HEALTH_CHECK_TYPE, null);
         String healthCheckHttpEndpoint = (String) PropertiesUtil.getPropertyValue(parametersList,
                                                                                   SupportedParameters.HEALTH_CHECK_HTTP_ENDPOINT,
@@ -67,6 +69,7 @@ public class StagingParametersParser implements ParametersParser<Staging> {
                                .stackName(stackName)
                                .healthCheckTimeout(healthCheckTimeout)
                                .invocationTimeout(healthCheckInvocationTimeout)
+                               .healthCheckInterval(healthCheckInterval)
                                .healthCheckType(healthCheckType)
                                .healthCheckHttpEndpoint(healthCheckHttpEndpoint)
                                .readinessHealthCheckType(readinessHealthCheckType)

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
@@ -20,6 +20,7 @@ import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_NOT
 import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_REQUIRED_FOR_CNB;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_NOT_ALLOWED_WITH_LIFECYCLE;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_REQUIRED;
+import static org.cloudfoundry.multiapps.controller.core.Messages.INVALID_HEALTH_CHECK_INTERVAL;
 import static org.cloudfoundry.multiapps.controller.core.Messages.UNSUPPORTED_LIFECYCLE_VALUE;
 
 public class StagingParametersParser implements ParametersParser<Staging> {
@@ -39,6 +40,7 @@ public class StagingParametersParser implements ParametersParser<Staging> {
                                                                                          null);
         Integer healthCheckInterval = (Integer) PropertiesUtil.getPropertyValue(parametersList,
                                                                                 SupportedParameters.HEALTH_CHECK_INTERVAL, null);
+        validateHealthCheckInterval(healthCheckInterval);
         String healthCheckType = (String) PropertiesUtil.getPropertyValue(parametersList, SupportedParameters.HEALTH_CHECK_TYPE, null);
         String healthCheckHttpEndpoint = (String) PropertiesUtil.getPropertyValue(parametersList,
                                                                                   SupportedParameters.HEALTH_CHECK_HTTP_ENDPOINT,
@@ -81,6 +83,12 @@ public class StagingParametersParser implements ParametersParser<Staging> {
                                .dockerInfo(dockerInfo)
                                .lifecycleType(lifecycleType)
                                .build();
+    }
+
+    private void validateHealthCheckInterval(Integer healthCheckInterval) {
+        if (healthCheckInterval != null && healthCheckInterval <= 0) {
+            throw new ContentException(MessageFormat.format(INVALID_HEALTH_CHECK_INTERVAL, healthCheckInterval));
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
@@ -21,6 +21,7 @@ import static org.cloudfoundry.multiapps.controller.core.Messages.UNSUPPORTED_LI
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACK;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACKS;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.DOCKER;
+import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.HEALTH_CHECK_INTERVAL;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.LIFECYCLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -136,6 +137,24 @@ class StagingParametersParserTest {
         assertNull(staging.getLifecycleType());
         assertTrue(CollectionUtils.isEmpty(staging.getBuildpacks()));
         assertNull(staging.getDockerInfo());
+    }
+
+    @Test
+    void testHealthCheckIntervalIsParsedWhenProvided() {
+        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, 15));
+
+        Staging staging = parser.parse(parametersList);
+
+        assertNotNull(staging);
+        assertEquals(15, staging.getHealthCheckInterval());
+    }
+
+    @Test
+    void testHealthCheckIntervalIsNullWhenAbsent() {
+        Staging staging = parser.parse(parametersList);
+
+        assertNotNull(staging);
+        assertNull(staging.getHealthCheckInterval());
     }
 
     private static Map<String, Object> mapOf(String key, Object value) {

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
@@ -17,7 +17,6 @@ import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_NOT
 import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_REQUIRED_FOR_CNB;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_NOT_ALLOWED_WITH_LIFECYCLE;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_REQUIRED;
-import static org.cloudfoundry.multiapps.controller.core.Messages.INVALID_HEALTH_CHECK_INTERVAL;
 import static org.cloudfoundry.multiapps.controller.core.Messages.UNSUPPORTED_LIFECYCLE_VALUE;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACK;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACKS;
@@ -156,32 +155,6 @@ class StagingParametersParserTest {
 
         assertNotNull(staging);
         assertNull(staging.getHealthCheckInterval());
-    }
-
-    @Test
-    void testHealthCheckIntervalAcceptsSmallestPositiveValue() {
-        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, 1));
-
-        Staging staging = parser.parse(parametersList);
-
-        assertNotNull(staging);
-        assertEquals(1, staging.getHealthCheckInterval());
-    }
-
-    @Test
-    void testHealthCheckIntervalRejectsZero() {
-        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, 0));
-
-        ContentException exception = assertThrows(ContentException.class, () -> parser.parse(parametersList));
-        assertEquals(MessageFormat.format(INVALID_HEALTH_CHECK_INTERVAL, 0), exception.getMessage());
-    }
-
-    @Test
-    void testHealthCheckIntervalRejectsNegative() {
-        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, -5));
-
-        ContentException exception = assertThrows(ContentException.class, () -> parser.parse(parametersList));
-        assertEquals(MessageFormat.format(INVALID_HEALTH_CHECK_INTERVAL, -5), exception.getMessage());
     }
 
     private static Map<String, Object> mapOf(String key, Object value) {

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
@@ -159,6 +159,16 @@ class StagingParametersParserTest {
     }
 
     @Test
+    void testHealthCheckIntervalAcceptsSmallestPositiveValue() {
+        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, 1));
+
+        Staging staging = parser.parse(parametersList);
+
+        assertNotNull(staging);
+        assertEquals(1, staging.getHealthCheckInterval());
+    }
+
+    @Test
     void testHealthCheckIntervalRejectsZero() {
         parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, 0));
 

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
@@ -17,6 +17,7 @@ import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_NOT
 import static org.cloudfoundry.multiapps.controller.core.Messages.BUILDPACKS_REQUIRED_FOR_CNB;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_NOT_ALLOWED_WITH_LIFECYCLE;
 import static org.cloudfoundry.multiapps.controller.core.Messages.DOCKER_INFO_REQUIRED;
+import static org.cloudfoundry.multiapps.controller.core.Messages.INVALID_HEALTH_CHECK_INTERVAL;
 import static org.cloudfoundry.multiapps.controller.core.Messages.UNSUPPORTED_LIFECYCLE_VALUE;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACK;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACKS;
@@ -155,6 +156,22 @@ class StagingParametersParserTest {
 
         assertNotNull(staging);
         assertNull(staging.getHealthCheckInterval());
+    }
+
+    @Test
+    void testHealthCheckIntervalRejectsZero() {
+        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, 0));
+
+        ContentException exception = assertThrows(ContentException.class, () -> parser.parse(parametersList));
+        assertEquals(MessageFormat.format(INVALID_HEALTH_CHECK_INTERVAL, 0), exception.getMessage());
+    }
+
+    @Test
+    void testHealthCheckIntervalRejectsNegative() {
+        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, -5));
+
+        ContentException exception = assertThrows(ContentException.class, () -> parser.parse(parametersList));
+        assertEquals(MessageFormat.format(INVALID_HEALTH_CHECK_INTERVAL, -5), exception.getMessage());
     }
 
     private static Map<String, Object> mapOf(String key, Object value) {

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/AdditionalModuleParametersReporter.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/util/AdditionalModuleParametersReporter.java
@@ -16,9 +16,15 @@ public class AdditionalModuleParametersReporter {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdditionalModuleParametersReporter.class);
 
     private final ProcessContext context;
+    private final Logger logger;
 
     public AdditionalModuleParametersReporter(ProcessContext context) {
+        this(context, LOGGER);
+    }
+
+    AdditionalModuleParametersReporter(ProcessContext context, Logger logger) {
         this.context = context;
+        this.logger = logger;
     }
 
     public void reportUsageOfAdditionalParameters(Module module) {
@@ -33,12 +39,17 @@ public class AdditionalModuleParametersReporter {
                                                                         .get(SupportedParameters.READINESS_HEALTH_CHECK_INVOCATION_TIMEOUT);
         Integer readinessHealthCheckInterval = (Integer) module.getParameters()
                                                                .get(SupportedParameters.READINESS_HEALTH_CHECK_INTERVAL);
+        Integer healthCheckInterval = (Integer) module.getParameters()
+                                                      .get(SupportedParameters.HEALTH_CHECK_INTERVAL);
         List<String> buildpacks = PropertiesUtil.getPluralOrSingular(List.of(module.getParameters()), SupportedParameters.BUILDPACKS,
                                                                      SupportedParameters.BUILDPACK);
         if (readinessHealthCheckType != null) {
             reportUsageOfReadinessHealthCheckParameters(mtaId, correlationId, readinessHealthCheckType, readinessHealthCheckHttpEndpoint,
                                                         readinessHealthCheckInvocationTimeout, readinessHealthCheckInterval,
                                                         buildpacks.toString(), module.getType());
+        }
+        if (healthCheckInterval != null) {
+            reportUsageOfHealthCheckInterval(mtaId, correlationId, healthCheckInterval, buildpacks.toString(), module.getType());
         }
     }
 
@@ -50,5 +61,11 @@ public class AdditionalModuleParametersReporter {
         LOGGER.info(MessageFormat.format("MTA with ID \"{0}\" associated with operation ID \"{1}\" uses readiness health check parameters: type=\"{2}\", httpEndpoint=\"{3}\", invocationTimeout=\"{4}\", interval=\"{5}\", buildpacks=\"{6}\", moduleType=\"{7}\"",
                                          mtaId, correlationId, readinessHealthCheckType, readinessHealthCheckHttpEndpoint,
                                          readinessHealthCheckInvocationTimeout, readinessHealthCheckInterval, buildpacks, moduleType));
+    }
+
+    private void reportUsageOfHealthCheckInterval(String mtaId, String correlationId, Integer healthCheckInterval, String buildpacks,
+                                                  String moduleType) {
+        logger.info(MessageFormat.format("MTA with ID \"{0}\" associated with operation ID \"{1}\" uses liveness health check parameters: interval=\"{2}\", buildpacks=\"{3}\", moduleType=\"{4}\"",
+                                         mtaId, correlationId, healthCheckInterval, buildpacks, moduleType));
     }
 }

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateStepWithExistingAppTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateStepWithExistingAppTest.java
@@ -111,7 +111,15 @@ class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<CreateO
                         true, LifecycleType.CNB),
                 Arguments.of(ImmutableStaging.builder().addBuildpack("buildpack-333").build(),
                         ImmutableStaging.builder().addBuildpacks("buildpack-4", "buildpack-8").lifecycleType(LifecycleType.CNB).build(),
-                        true, LifecycleType.CNB));
+                        true, LifecycleType.CNB),
+                Arguments.of(
+                        ImmutableStaging.builder().addBuildpack("buildpack-1").healthCheckType("port").healthCheckInterval(10).build(),
+                        ImmutableStaging.builder().addBuildpack("buildpack-1").healthCheckType("port").healthCheckInterval(20).build(),
+                        true, LifecycleType.BUILDPACK),
+                Arguments.of(
+                        ImmutableStaging.builder().addBuildpack("buildpack-1").healthCheckType("port").healthCheckInterval(10).build(),
+                        ImmutableStaging.builder().addBuildpack("buildpack-1").healthCheckType("port").healthCheckInterval(10).build(),
+                        false, LifecycleType.BUILDPACK));
 //@formatter:on
     }
 
@@ -232,6 +240,7 @@ class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<CreateO
         String command = staging.getCommand() == null ? DEFAULT_COMMAND : staging.getCommand();
         var hcType = staging.getHealthCheckType();
         var hcTimeout = staging.getHealthCheckTimeout();
+        var hcInterval = staging.getHealthCheckInterval();
         var hcEndpoint = staging.getHealthCheckHttpEndpoint();
         when(client.getApplicationProcess(application.getGuid())).thenReturn(ImmutableCloudProcess.builder()
                                                                                                   .command(command)
@@ -243,6 +252,7 @@ class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<CreateO
                                                                                                                        : HealthCheckType.valueOf(
                                                                                                                            hcType.toUpperCase()))
                                                                                                   .healthCheckTimeout(hcTimeout)
+                                                                                                  .healthCheckInterval(hcInterval)
                                                                                                   .healthCheckHttpEndpoint(hcEndpoint)
                                                                                                   .instances(1)
                                                                                                   .build());

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/AdditionalModuleParametersReporterTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/util/AdditionalModuleParametersReporterTest.java
@@ -1,0 +1,81 @@
+package org.cloudfoundry.multiapps.controller.process.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.cloudfoundry.multiapps.controller.core.cf.CloudControllerClientProvider;
+import org.cloudfoundry.multiapps.controller.process.steps.ProcessContext;
+import org.cloudfoundry.multiapps.controller.process.variables.Variables;
+import org.cloudfoundry.multiapps.mta.model.DeploymentDescriptor;
+import org.cloudfoundry.multiapps.mta.model.Module;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class AdditionalModuleParametersReporterTest {
+
+    private static final String MTA_ID = "test-mta";
+    private static final String CORRELATION_ID = "test-correlation-id";
+
+    @Test
+    void testHealthCheckIntervalLoggedWhenSet() {
+        Logger mockLogger = Mockito.mock(Logger.class);
+        Module module = createModule(Map.of("health-check-interval", 30));
+
+        new AdditionalModuleParametersReporter(createContext(), mockLogger).reportUsageOfAdditionalParameters(module);
+
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockLogger, atLeastOnce()).info(messageCaptor.capture());
+        long livenessLogs = messageCaptor.getAllValues()
+                                         .stream()
+                                         .filter(message -> message.contains("liveness health check"))
+                                         .count();
+        assertEquals(1, livenessLogs);
+        String message = messageCaptor.getAllValues()
+                                      .stream()
+                                      .filter(formatted -> formatted.contains("liveness health check"))
+                                      .findFirst()
+                                      .orElseThrow();
+        assertTrue(message.contains("interval=\"30\""), "Log message should contain interval=\"30\", was: " + message);
+        assertTrue(message.contains(MTA_ID), "Log message should contain MTA id, was: " + message);
+        assertTrue(message.contains(CORRELATION_ID), "Log message should contain correlation id, was: " + message);
+    }
+
+    @Test
+    void testHealthCheckIntervalNotLoggedWhenAbsent() {
+        Logger mockLogger = Mockito.mock(Logger.class);
+        Module module = createModule(new HashMap<>());
+
+        new AdditionalModuleParametersReporter(createContext(), mockLogger).reportUsageOfAdditionalParameters(module);
+
+        verify(mockLogger, never()).info(anyString());
+    }
+
+    private static Module createModule(Map<String, Object> parameters) {
+        return Module.createV3()
+                     .setName("test-module")
+                     .setType("application")
+                     .setParameters(parameters);
+    }
+
+    private static ProcessContext createContext() {
+        DelegateExecution delegateExecution = MockDelegateExecution.createSpyInstance();
+        StepLogger stepLogger = Mockito.mock(StepLogger.class);
+        CloudControllerClientProvider cloudControllerClientProvider = Mockito.mock(CloudControllerClientProvider.class);
+        ProcessContext context = new ProcessContext(delegateExecution, stepLogger, cloudControllerClientProvider);
+        DeploymentDescriptor deploymentDescriptor = DeploymentDescriptor.createV3()
+                                                                       .setId(MTA_ID);
+        context.setVariable(Variables.DEPLOYMENT_DESCRIPTOR, deploymentDescriptor);
+        context.setVariable(Variables.CORRELATION_ID, CORRELATION_ID);
+        return context;
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for the `health-check-interval` MTA module parameter, bringing feature parity with native Cloud Foundry. Application descriptors can now configure the interval (in seconds) between liveness health-check probes.

```yaml
modules:
  - name: my-app
    type: application
    parameters:
      health-check-interval: 15
```

The parameter was previously not exposable through MTA because the underlying CF Java client did not surface it; recent client versions do, so this change wires it through the controller.

## What changed

**multiapps-controller-client**
- `Staging` and `HealthCheckInfo` carry the new `healthCheckInterval` field.
- `RawCloudProcess` round-trips the field when adapting the CF client's `Process` resource.
- `CloudControllerRestClientImpl` forwards the value to the CF Java client when staging an app.

**multiapps-controller-core**
- `SupportedParameters` registers `health-check-interval` so it is recognised at parse time.
- `StagingParametersParser` reads the parameter and rejects non-positive values.

**multiapps-controller-process**
- `AdditionalModuleParametersReporter` includes the parameter in usage telemetry.
- Drift detection in `CreateOrUpdateAppStep` now triggers an update when the interval changes.

## Tests

| File | Cases | Notes |
|---|---|---|
| `RawCloudProcessTest` | 3 | round-trip of liveness interval |
| `HealthCheckInfoTest` | 8 | covers boundaries and defaults |
| `StagingParametersParserTest` | +2 | non-positive rejection, boundary |
| `AdditionalModuleParametersReporterTest` | 2 | reporting on/off paths |
| `CreateOrUpdateStepWithExistingAppTest` | +2 | drift detection when interval changes |

Verified locally with:

```
mvn -pl multiapps-controller-client,multiapps-controller-core,multiapps-controller-process -am test \
    -Dtest=RawCloudProcessTest,HealthCheckInfoTest,StagingParametersParserTest,AdditionalModuleParametersReporterTest,CreateOrUpdateStepWithExistingAppTest \
    -Dsurefire.failIfNoSpecifiedTests=false
```

## Tracking

JIRA:LMCROSSITXSADEPLOY-3316
