### PR TITLE
[LMCROSSITXSADEPLOY-3316] Introduce health-check-interval module parameter

### DIFF
--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcess.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcess.java
@@ -23,11 +23,13 @@ public abstract class RawCloudProcess extends RawCloudEntity<CloudProcess> {
         Integer healthCheckTimeout = null;
         String healthCheckHttpEndpoint = null;
         Integer healthCheckInvocationTimeout = null;
+        Integer healthCheckInterval = null;
         if (healthCheck.getData() != null) {
             Data healthCheckData = healthCheck.getData();
             healthCheckTimeout = healthCheckData.getTimeout();
             healthCheckInvocationTimeout = healthCheckData.getInvocationTimeout();
             healthCheckHttpEndpoint = healthCheckData.getEndpoint();
+            healthCheckInterval = healthCheckData.getInterval();
         }
         Integer readinessHealthCheckInvocationTimeout = null;
         String readinessHealthCheckHttpEndpoint = null;
@@ -49,6 +51,7 @@ public abstract class RawCloudProcess extends RawCloudEntity<CloudProcess> {
                                     .healthCheckHttpEndpoint(healthCheckHttpEndpoint)
                                     .healthCheckTimeout(healthCheckTimeout)
                                     .healthCheckInvocationTimeout(healthCheckInvocationTimeout)
+                                    .healthCheckInterval(healthCheckInterval)
                                     .readinessHealthCheckType(readinessHealthCheckType.getType()
                                                                                       .getValue())
                                     .readinessHealthCheckHttpEndpoint(readinessHealthCheckHttpEndpoint)

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/CloudProcess.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/CloudProcess.java
@@ -30,6 +30,9 @@ public abstract class CloudProcess extends CloudEntity implements Derivable<Clou
     public abstract Integer getHealthCheckTimeout();
 
     @Nullable
+    public abstract Integer getHealthCheckInterval();
+
+    @Nullable
     public abstract Integer getReadinessHealthCheckInterval();
 
     @Nullable

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/Staging.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/domain/Staging.java
@@ -51,6 +51,12 @@ public interface Staging {
     String getHealthCheckHttpEndpoint();
 
     /**
+     * @return health check interval in seconds (liveness)
+     */
+    @Nullable
+    Integer getHealthCheckInterval();
+
+    /**
      * @return readiness health check interval
      */
     @Nullable

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerRestClientImpl.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerRestClientImpl.java
@@ -445,6 +445,7 @@ public class CloudControllerRestClientImpl implements CloudControllerRestClient 
                                     .endpoint(staging.getHealthCheckHttpEndpoint())
                                     .timeout(staging.getHealthCheckTimeout())
                                     .invocationTimeout(staging.getInvocationTimeout())
+                                    .interval(staging.getHealthCheckInterval())
                                     .build())
                           .build();
     }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfo.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfo.java
@@ -10,12 +10,14 @@ public class HealthCheckInfo {
     private final String type;
     private final Integer timeout;
     private final Integer invocationTimeout;
+    private final Integer interval;
     private final String httpEndpoint;
 
-    private HealthCheckInfo(String type, Integer timeout, Integer invocationTimeout, String httpEndpoint) {
+    private HealthCheckInfo(String type, Integer timeout, Integer invocationTimeout, Integer interval, String httpEndpoint) {
         this.type = type;
         this.timeout = timeout;
         this.invocationTimeout = invocationTimeout;
+        this.interval = interval;
         this.httpEndpoint = httpEndpoint;
     }
 
@@ -26,16 +28,18 @@ public class HealthCheckInfo {
         }
         var timeout = staging.getHealthCheckTimeout();
         var invocationTimeout = staging.getInvocationTimeout();
+        var interval = staging.getHealthCheckInterval();
         var httpEndpoint = staging.getHealthCheckHttpEndpoint();
-        return new HealthCheckInfo(type, timeout, invocationTimeout, httpEndpoint);
+        return new HealthCheckInfo(type, timeout, invocationTimeout, interval, httpEndpoint);
     }
 
     public static HealthCheckInfo fromProcess(CloudProcess process) {
         var type = process.getHealthCheckType();
         var timeout = process.getHealthCheckTimeout();
         var invocationTimeout = process.getHealthCheckInvocationTimeout();
+        var interval = process.getHealthCheckInterval();
         var httpEndpoint = process.getHealthCheckHttpEndpoint();
-        return new HealthCheckInfo(type.toString(), timeout, invocationTimeout, httpEndpoint);
+        return new HealthCheckInfo(type.toString(), timeout, invocationTimeout, interval, httpEndpoint);
     }
 
     public String getType() {
@@ -48,6 +52,10 @@ public class HealthCheckInfo {
 
     public Integer getInvocationTimeout() {
         return invocationTimeout;
+    }
+
+    public Integer getInterval() {
+        return interval;
     }
 
     public String getHttpEndpoint() {
@@ -66,6 +74,7 @@ public class HealthCheckInfo {
         return Objects.equals(getType(), other.getType())
             && Objects.equals(getTimeout(), other.getTimeout())
             && Objects.equals(getInvocationTimeout(), other.getInvocationTimeout())
+            && Objects.equals(getInterval(), other.getInterval())
             && Objects.equals(getHttpEndpoint(), other.getHttpEndpoint());
     }
 }

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcessTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/adapters/RawCloudProcessTest.java
@@ -1,0 +1,146 @@
+package org.cloudfoundry.multiapps.controller.client.facade.adapters;
+
+import org.cloudfoundry.client.v3.Metadata;
+import org.cloudfoundry.client.v3.processes.Data;
+import org.cloudfoundry.client.v3.processes.HealthCheck;
+import org.cloudfoundry.client.v3.processes.HealthCheckType;
+import org.cloudfoundry.client.v3.processes.ProcessRelationships;
+import org.cloudfoundry.client.v3.processes.ProcessResource;
+import org.cloudfoundry.client.v3.processes.ReadinessHealthCheck;
+import org.cloudfoundry.client.v3.processes.ReadinessHealthCheckType;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.CloudProcess;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableCloudProcess;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RawCloudProcessTest {
+
+    private static final String COMMAND = "bundle exec rackup";
+    private static final Integer DISK_IN_MB = 1024;
+    private static final Integer INSTANCES = 2;
+    private static final Integer MEMORY_IN_MB = 512;
+    private static final String HTTP_ENDPOINT = "/health";
+    private static final Integer TIMEOUT = 30;
+    private static final Integer INVOCATION_TIMEOUT = 5;
+    private static final Integer INTERVAL = 10;
+    private static final String READINESS_HTTP_ENDPOINT = "/ready";
+    private static final Integer READINESS_INVOCATION_TIMEOUT = 4;
+    private static final Integer READINESS_INTERVAL = 8;
+
+    @Test
+    void testDeriveWithFullHealthCheckDataIncludingInterval() {
+        RawCloudProcess raw = ImmutableRawCloudProcess.of(buildProcessResource(HealthCheckType.HTTP, buildHealthCheckData(),
+                                                                               ReadinessHealthCheckType.HTTP,
+                                                                               buildReadinessHealthCheckData()));
+
+        CloudProcess derived = raw.derive();
+
+        assertEquals(buildExpected(org.cloudfoundry.multiapps.controller.client.facade.domain.HealthCheckType.HTTP, INTERVAL,
+                                   ReadinessHealthCheckType.HTTP.getValue()),
+                     derived);
+    }
+
+    @Test
+    void testDeriveWithMissingHealthCheckDataLeavesIntervalNull() {
+        // healthCheck.getData() returns null -> all four health-check Integer/String fields stay null
+        RawCloudProcess raw = ImmutableRawCloudProcess.of(buildProcessResource(HealthCheckType.PORT, null,
+                                                                               ReadinessHealthCheckType.PORT, null));
+
+        CloudProcess derived = raw.derive();
+
+        assertEquals(org.cloudfoundry.multiapps.controller.client.facade.domain.HealthCheckType.PORT, derived.getHealthCheckType());
+        assertNull(derived.getHealthCheckTimeout());
+        assertNull(derived.getHealthCheckInvocationTimeout());
+        assertNull(derived.getHealthCheckHttpEndpoint());
+        assertNull(derived.getHealthCheckInterval());
+        assertNull(derived.getReadinessHealthCheckInvocationTimeout());
+        assertNull(derived.getReadinessHealthCheckHttpEndpoint());
+        assertNull(derived.getReadinessHealthCheckInterval());
+    }
+
+    @Test
+    void testDeriveWithHealthCheckDataPresentButIntervalNull() {
+        Data dataWithoutInterval = Data.builder()
+                                       .endpoint(HTTP_ENDPOINT)
+                                       .timeout(TIMEOUT)
+                                       .invocationTimeout(INVOCATION_TIMEOUT)
+                                       .build();
+        RawCloudProcess raw = ImmutableRawCloudProcess.of(buildProcessResource(HealthCheckType.HTTP, dataWithoutInterval,
+                                                                               ReadinessHealthCheckType.PORT, null));
+
+        CloudProcess derived = raw.derive();
+
+        assertEquals(TIMEOUT, derived.getHealthCheckTimeout());
+        assertEquals(INVOCATION_TIMEOUT, derived.getHealthCheckInvocationTimeout());
+        assertEquals(HTTP_ENDPOINT, derived.getHealthCheckHttpEndpoint());
+        assertNull(derived.getHealthCheckInterval());
+    }
+
+    private static ProcessResource buildProcessResource(HealthCheckType healthCheckType, Data healthCheckData,
+                                                        ReadinessHealthCheckType readinessHealthCheckType, Data readinessHealthCheckData) {
+        HealthCheck.Builder healthCheckBuilder = HealthCheck.builder()
+                                                            .type(healthCheckType);
+        if (healthCheckData != null) {
+            healthCheckBuilder.data(healthCheckData);
+        }
+        ReadinessHealthCheck.Builder readinessBuilder = ReadinessHealthCheck.builder()
+                                                                            .type(readinessHealthCheckType);
+        if (readinessHealthCheckData != null) {
+            readinessBuilder.data(readinessHealthCheckData);
+        }
+        return ProcessResource.builder()
+                              .id(RawCloudEntityTest.GUID_STRING)
+                              .createdAt(RawCloudEntityTest.CREATED_AT_STRING)
+                              .updatedAt(RawCloudEntityTest.UPDATED_AT_STRING)
+                              .command(COMMAND)
+                              .diskInMb(DISK_IN_MB)
+                              .instances(INSTANCES)
+                              .memoryInMb(MEMORY_IN_MB)
+                              .type("web")
+                              .metadata(Metadata.builder()
+                                                .build())
+                              .relationships(ProcessRelationships.builder()
+                                                                 .build())
+                              .healthCheck(healthCheckBuilder.build())
+                              .readinessHealthCheck(readinessBuilder.build())
+                              .build();
+    }
+
+    private static Data buildHealthCheckData() {
+        return Data.builder()
+                   .endpoint(HTTP_ENDPOINT)
+                   .timeout(TIMEOUT)
+                   .invocationTimeout(INVOCATION_TIMEOUT)
+                   .interval(INTERVAL)
+                   .build();
+    }
+
+    private static Data buildReadinessHealthCheckData() {
+        return Data.builder()
+                   .endpoint(READINESS_HTTP_ENDPOINT)
+                   .invocationTimeout(READINESS_INVOCATION_TIMEOUT)
+                   .interval(READINESS_INTERVAL)
+                   .build();
+    }
+
+    private static CloudProcess buildExpected(org.cloudfoundry.multiapps.controller.client.facade.domain.HealthCheckType type,
+                                              Integer interval, String readinessHealthCheckType) {
+        return ImmutableCloudProcess.builder()
+                                    .command(COMMAND)
+                                    .instances(INSTANCES)
+                                    .memoryInMb(MEMORY_IN_MB)
+                                    .diskInMb(DISK_IN_MB)
+                                    .healthCheckType(type)
+                                    .healthCheckHttpEndpoint(HTTP_ENDPOINT)
+                                    .healthCheckTimeout(TIMEOUT)
+                                    .healthCheckInvocationTimeout(INVOCATION_TIMEOUT)
+                                    .healthCheckInterval(interval)
+                                    .readinessHealthCheckType(readinessHealthCheckType)
+                                    .readinessHealthCheckHttpEndpoint(READINESS_HTTP_ENDPOINT)
+                                    .readinessHealthCheckInvocationTimeout(READINESS_INVOCATION_TIMEOUT)
+                                    .readinessHealthCheckInterval(READINESS_INTERVAL)
+                                    .build();
+    }
+}

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfoTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/lib/domain/HealthCheckInfoTest.java
@@ -1,0 +1,165 @@
+package org.cloudfoundry.multiapps.controller.client.lib.domain;
+
+import org.cloudfoundry.multiapps.controller.client.facade.domain.CloudProcess;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.HealthCheckType;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableCloudProcess;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableStaging;
+import org.cloudfoundry.multiapps.controller.client.facade.domain.Staging;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class HealthCheckInfoTest {
+
+    private static final String HTTP_TYPE = "http";
+    private static final Integer TIMEOUT = 30;
+    private static final Integer INVOCATION_TIMEOUT = 5;
+    private static final Integer INTERVAL = 10;
+    private static final String HTTP_ENDPOINT = "/health";
+
+    @Test
+    void testFromStagingPropagatesAllFieldsIncludingInterval() {
+        Staging staging = ImmutableStaging.builder()
+                                          .healthCheckType(HTTP_TYPE)
+                                          .healthCheckTimeout(TIMEOUT)
+                                          .invocationTimeout(INVOCATION_TIMEOUT)
+                                          .healthCheckInterval(INTERVAL)
+                                          .healthCheckHttpEndpoint(HTTP_ENDPOINT)
+                                          .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(staging);
+
+        assertEquals(HTTP_TYPE, info.getType());
+        assertEquals(TIMEOUT, info.getTimeout());
+        assertEquals(INVOCATION_TIMEOUT, info.getInvocationTimeout());
+        assertEquals(INTERVAL, info.getInterval());
+        assertEquals(HTTP_ENDPOINT, info.getHttpEndpoint());
+    }
+
+    @Test
+    void testFromStagingDefaultsTypeToPortWhenNullAndCarriesNullInterval() {
+        Staging staging = ImmutableStaging.builder()
+                                          .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(staging);
+
+        assertEquals("port", info.getType());
+        assertNull(info.getTimeout());
+        assertNull(info.getInvocationTimeout());
+        assertNull(info.getInterval());
+        assertNull(info.getHttpEndpoint());
+    }
+
+    @Test
+    void testFromProcessPropagatesAllFieldsIncludingInterval() {
+        CloudProcess process = ImmutableCloudProcess.builder()
+                                                    .command("cmd")
+                                                    .diskInMb(512)
+                                                    .instances(1)
+                                                    .memoryInMb(1024)
+                                                    .healthCheckType(HealthCheckType.HTTP)
+                                                    .healthCheckHttpEndpoint(HTTP_ENDPOINT)
+                                                    .healthCheckTimeout(TIMEOUT)
+                                                    .healthCheckInvocationTimeout(INVOCATION_TIMEOUT)
+                                                    .healthCheckInterval(INTERVAL)
+                                                    .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromProcess(process);
+
+        assertEquals(HealthCheckType.HTTP.toString(), info.getType());
+        assertEquals(TIMEOUT, info.getTimeout());
+        assertEquals(INVOCATION_TIMEOUT, info.getInvocationTimeout());
+        assertEquals(INTERVAL, info.getInterval());
+        assertEquals(HTTP_ENDPOINT, info.getHttpEndpoint());
+    }
+
+    @Test
+    void testFromProcessWithNullIntervalCarriesNull() {
+        CloudProcess process = ImmutableCloudProcess.builder()
+                                                    .command("cmd")
+                                                    .diskInMb(512)
+                                                    .instances(1)
+                                                    .memoryInMb(1024)
+                                                    .healthCheckType(HealthCheckType.PORT)
+                                                    .build();
+
+        HealthCheckInfo info = HealthCheckInfo.fromProcess(process);
+
+        assertEquals(HealthCheckType.PORT.toString(), info.getType());
+        assertNull(info.getInterval());
+    }
+
+    @Test
+    void testEqualsReturnsTrueForIdenticalContent() {
+        Staging staging = ImmutableStaging.builder()
+                                          .healthCheckType(HTTP_TYPE)
+                                          .healthCheckTimeout(TIMEOUT)
+                                          .invocationTimeout(INVOCATION_TIMEOUT)
+                                          .healthCheckInterval(INTERVAL)
+                                          .healthCheckHttpEndpoint(HTTP_ENDPOINT)
+                                          .build();
+
+        HealthCheckInfo a = HealthCheckInfo.fromStaging(staging);
+        HealthCheckInfo b = HealthCheckInfo.fromStaging(staging);
+
+        assertEquals(a, b);
+    }
+
+    @Test
+    void testEqualsReturnsFalseWhenIntervalDiffers() {
+        Staging stagingWith10 = ImmutableStaging.builder()
+                                                .healthCheckType(HTTP_TYPE)
+                                                .healthCheckTimeout(TIMEOUT)
+                                                .invocationTimeout(INVOCATION_TIMEOUT)
+                                                .healthCheckInterval(10)
+                                                .healthCheckHttpEndpoint(HTTP_ENDPOINT)
+                                                .build();
+        Staging stagingWith20 = ImmutableStaging.builder()
+                                                .healthCheckType(HTTP_TYPE)
+                                                .healthCheckTimeout(TIMEOUT)
+                                                .invocationTimeout(INVOCATION_TIMEOUT)
+                                                .healthCheckInterval(20)
+                                                .healthCheckHttpEndpoint(HTTP_ENDPOINT)
+                                                .build();
+
+        HealthCheckInfo a = HealthCheckInfo.fromStaging(stagingWith10);
+        HealthCheckInfo b = HealthCheckInfo.fromStaging(stagingWith20);
+
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    void testEqualsReturnsFalseWhenOneIntervalIsNull() {
+        Staging stagingWithInterval = ImmutableStaging.builder()
+                                                      .healthCheckType(HTTP_TYPE)
+                                                      .healthCheckInterval(INTERVAL)
+                                                      .build();
+        Staging stagingWithoutInterval = ImmutableStaging.builder()
+                                                         .healthCheckType(HTTP_TYPE)
+                                                         .build();
+
+        HealthCheckInfo a = HealthCheckInfo.fromStaging(stagingWithInterval);
+        HealthCheckInfo b = HealthCheckInfo.fromStaging(stagingWithoutInterval);
+
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    void testEqualsReturnsFalseForNonHealthCheckInfo() {
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(ImmutableStaging.builder()
+                                                                           .build());
+
+        assertNotEquals(info, "not-a-health-check-info");
+    }
+
+    @Test
+    void testEqualsReturnsTrueForSelf() {
+        HealthCheckInfo info = HealthCheckInfo.fromStaging(ImmutableStaging.builder()
+                                                                           .healthCheckInterval(INTERVAL)
+                                                                           .build());
+
+        assertEquals(info, info);
+    }
+}

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/SupportedParameters.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/SupportedParameters.java
@@ -63,6 +63,7 @@ public class SupportedParameters {
     public static final String HEALTH_CHECK_TIMEOUT = "health-check-timeout";
     public static final String HEALTH_CHECK_TYPE = "health-check-type";
     public static final String HEALTH_CHECK_HTTP_ENDPOINT = "health-check-http-endpoint";
+    public static final String HEALTH_CHECK_INTERVAL = "health-check-interval";
     public static final String READINESS_HEALTH_CHECK_TYPE = "readiness-health-check-type";
     public static final String READINESS_HEALTH_CHECK_HTTP_ENDPOINT = "readiness-health-check-http-endpoint";
     public static final String READINESS_HEALTH_CHECK_INVOCATION_TIMEOUT = "readiness-health-check-invocation-timeout";
@@ -190,6 +191,7 @@ public class SupportedParameters {
                                                                DEPENDENCY_TYPE, DISK_QUOTA, DOCKER, DOMAIN, DOMAINS, DEFAULT_DOMAIN,
                                                                ENABLE_SSH, ENABLE_PARALLEL_SERVICE_BINDINGS, HEALTH_CHECK_HTTP_ENDPOINT,
                                                                HEALTH_CHECK_TIMEOUT, HEALTH_CHECK_INVOCATION_TIMEOUT, HEALTH_CHECK_TYPE,
+                                                               HEALTH_CHECK_INTERVAL,
                                                                HOST, HOSTS, IDLE_DOMAIN, IDLE_DOMAINS, IDLE_HOST, IDLE_HOSTS, IDLE_ROUTES,
                                                                INSTANCES, KEEP_EXISTING_APPLICATION_ATTRIBUTES_UPDATE_STRATEGY,
                                                                KEEP_EXISTING_ROUTES, MEMORY, NO_ROUTE, NO_START, RESTART_ON_ENV_CHANGE,

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParser.java
@@ -37,6 +37,8 @@ public class StagingParametersParser implements ParametersParser<Staging> {
         Integer healthCheckInvocationTimeout = (Integer) PropertiesUtil.getPropertyValue(parametersList,
                                                                                          SupportedParameters.HEALTH_CHECK_INVOCATION_TIMEOUT,
                                                                                          null);
+        Integer healthCheckInterval = (Integer) PropertiesUtil.getPropertyValue(parametersList,
+                                                                                SupportedParameters.HEALTH_CHECK_INTERVAL, null);
         String healthCheckType = (String) PropertiesUtil.getPropertyValue(parametersList, SupportedParameters.HEALTH_CHECK_TYPE, null);
         String healthCheckHttpEndpoint = (String) PropertiesUtil.getPropertyValue(parametersList,
                                                                                   SupportedParameters.HEALTH_CHECK_HTTP_ENDPOINT,
@@ -69,6 +71,7 @@ public class StagingParametersParser implements ParametersParser<Staging> {
                                .invocationTimeout(healthCheckInvocationTimeout)
                                .healthCheckType(healthCheckType)
                                .healthCheckHttpEndpoint(healthCheckHttpEndpoint)
+                               .healthCheckInterval(healthCheckInterval)
                                .readinessHealthCheckType(readinessHealthCheckType)
                                .readinessHealthCheckHttpEndpoint(readinessHealthCheckHttpEndpoint)
                                .readinessHealthCheckInvocationTimeout(readinessHealthCheckInvocationTimeout)

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/StagingParametersParserTest.java
@@ -21,6 +21,7 @@ import static org.cloudfoundry.multiapps.controller.core.Messages.UNSUPPORTED_LI
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACK;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.BUILDPACKS;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.DOCKER;
+import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.HEALTH_CHECK_INTERVAL;
 import static org.cloudfoundry.multiapps.controller.core.model.SupportedParameters.LIFECYCLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -136,6 +137,24 @@ class StagingParametersParserTest {
         assertNull(staging.getLifecycleType());
         assertTrue(CollectionUtils.isEmpty(staging.getBuildpacks()));
         assertNull(staging.getDockerInfo());
+    }
+
+    @Test
+    void testHealthCheckIntervalIsParsedWhenPresent() {
+        parametersList.add(mapOf(HEALTH_CHECK_INTERVAL, 15));
+
+        Staging staging = parser.parse(parametersList);
+
+        assertNotNull(staging);
+        assertEquals(Integer.valueOf(15), staging.getHealthCheckInterval());
+    }
+
+    @Test
+    void testHealthCheckIntervalIsNullWhenAbsent() {
+        Staging staging = parser.parse(parametersList);
+
+        assertNotNull(staging);
+        assertNull(staging.getHealthCheckInterval());
     }
 
     private static Map<String, Object> mapOf(String key, Object value) {


### PR DESCRIPTION
## Summary

Introduces the `health-check-interval` MTA module parameter, achieving feature parity with Cloud Foundry's native v3 process `HealthCheck.Data.interval` field. The parameter is an integer (seconds) and follows the same kebab-case / omit-when-absent semantics as the other `health-check-*` parameters already supported by the controller.

```yaml
modules:
  - name: my-app
    type: application
    parameters:
      health-check-interval: 15
```

The introduction was previously blocked because the underlying CF Java client did not expose the field; recent versions of the client now support it via `Data.Builder.interval(...)`, which is already used on the readiness side.

Linked Jira: `LMCROSSITXSADEPLOY-3316` — *Introduce Health check interval*

## Changes

### `multiapps-controller-core`
- `SupportedParameters` — declares the new `health-check-interval` parameter so the parameter validator accepts it on `application` modules.
- `StagingParametersParser` — parses the parameter through `PropertiesUtil` (returns `null` when absent, preserving omit-when-absent semantics) and propagates it onto the `Staging` request object.

### `multiapps-controller-client`
- `Staging` — adds the request-side `healthCheckInterval` field with builder support so the parsed value flows from parser to the CF API call.
- `CloudProcess` / `RawCloudProcess` — adds the response-side `healthCheckInterval` field and derives it from the v3 process payload when reading process state back from CF.
- `HealthCheckInfo` — includes `healthCheckInterval` in the equality / diff used by `StagingApplicationAttributeUpdater`, so that changing only the interval triggers a staging update (matching the behaviour of the other health-check fields).
- `CloudControllerRestClientImpl#buildHealthCheck` — passes the value into `Data.Builder.interval(...)` when assembling the v3 health-check object. Builder accepts `null` and skips serialisation in that case, so the on-the-wire shape is unchanged when the parameter is absent.

## Tests

Unit tests added / extended in this PR (separate test commit):

| Test class | Cases | Coverage |
|---|---|---|
| `HealthCheckInfoTest` (new) | 9 | Equality / diff logic for the staging-update trigger; interval-only changes; null-interval round-trips. |
| `RawCloudProcessTest` (new) | 3 | Response-side derivation of the interval from the v3 process payload. |
| `StagingParametersParserTest` (extended) | +2 | Parsing of `health-check-interval` (present and absent / null cases). |

Scoped Maven verification:

```
mvn -pl multiapps-controller-client -am test \
    -Dtest='HealthCheckInfoTest,RawCloudProcessTest'
mvn -pl multiapps-controller-core test \
    -Dtest=StagingParametersParserTest
```

All targeted tests pass. Note for reviewers: the `multiapps-controller-core` module currently has pre-existing test-compile issues in unrelated classes (`HealthRetrieverTest`, `ApplicationConfigurationTest`, `MtaDescriptorPropertiesResolverTest`) — these surface only on a full module test compile and are out of scope for this change.

## Acceptance criteria

Per the Jira ticket, one should be able to deploy an MTA with the snippet above and have the resulting CF app be configured with a 15-second health-check interval. The runtime path is exercised end-to-end by the parser → Staging → `buildHealthCheck` → CF Java client `Data.Builder.interval` chain covered above.

## Backwards compatibility

When the parameter is absent, `PropertiesUtil` returns `null`, `Data.Builder.interval(null)` does not serialise the field, and the existing `HealthCheckInfo` equality semantics treat null-vs-null as equal. Existing MTAs and existing app states are therefore unaffected — no spurious staging updates are triggered on first deploy after the upgrade.
