### PR TITLE
Improve Swagger API documentation across REST facade classes

### DIFF
--- a/multiapps-controller-api/pom.xml
+++ b/multiapps-controller-api/pom.xml
@@ -120,7 +120,27 @@
                                     <swaggerFileName>mtarest</swaggerFileName>
                                     <info>
                                         <title>MTA REST API</title>
-                                        <description>This is the API of the Cloud Foundry MultiApps Controller
+                                        <description>This is the API of the Cloud Foundry MultiApps Controller.
+
+## Typical deploy sequence
+
+Step 1 (optional) — Obtain a CSRF token:
+  GET /api/v1/csrf-token
+
+Step 2 — Upload the MTA archive:
+  POST /api/v1/spaces/{spaceGuid}/files
+
+Step 3 — Start a deploy operation:
+  POST /api/v1/spaces/{spaceGuid}/operations
+  Request body: Operation object with processType=DEPLOY and mtaId.
+
+Step 4 — Poll operation status:
+  GET /api/v1/spaces/{spaceGuid}/operations/{operationId}
+  Repeat until state is one of: FINISHED, ERROR, ABORTED, ACTION_REQUIRED.
+
+Step 5 (optional) — Execute an action:
+  POST /api/v1/spaces/{spaceGuid}/operations/{operationId}?actionId=abort|retry
+  Use when state is ACTION_REQUIRED or to abort a running operation.
                                         </description>
                                         <version>1.4.0</version>
                                     </info>
@@ -147,6 +167,34 @@
                                     </info>
                                 </apiSource>
                             </apiSources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Quotes integer response-code keys (e.g. 200: -> "200":) in generated YAML.
+                 Required because Kongchen swagger-maven-plugin 3.1.8 emits bare integers,
+                 but the Swagger 2.0 spec and SAP API Metadata Validator require string keys. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>quote-yaml-response-codes</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <replaceregexp file="${project.basedir}/src/main/resources/mtarest.yaml"
+                                               match="^(\s+)([0-9]{3}):"
+                                               replace='\1"\2":'
+                                               byline="true"/>
+                                <replaceregexp file="${project.basedir}/src/main/resources/mtarest_v2.yaml"
+                                               match="^(\s+)([0-9]{3}):"
+                                               replace='\1"\2":'
+                                               byline="true"/>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/multiapps-controller-api/pom.xml
+++ b/multiapps-controller-api/pom.xml
@@ -173,7 +173,10 @@ Step 5 (optional) — Execute an action:
             </plugin>
             <!-- Quotes integer response-code keys (e.g. 200: -> "200":) in generated YAML.
                  Required because Kongchen swagger-maven-plugin 3.1.8 emits bare integers,
-                 but the Swagger 2.0 spec and SAP API Metadata Validator require string keys. -->
+                 but the Swagger 2.0 spec requires string keys for response codes.
+                 This transformation is idempotent: already-quoted keys (e.g. "200":) do not
+                 match the bare-integer regex, so running mvn compile on a clean checkout with
+                 pre-quoted source files leaves the working tree unmodified. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/Constants.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/Constants.java
@@ -71,4 +71,24 @@ public class Constants {
 
     }
 
+    public static class HttpResponses {
+
+        private HttpResponses() {
+        }
+
+        public static final String OK = "OK";
+        public static final String CREATED = "Created";
+        public static final String NO_CONTENT = "No Content";
+        public static final String ACCEPTED = "Accepted";
+        public static final String BAD_REQUEST = "Bad Request";
+        public static final String UNAUTHORIZED = "Unauthorized";
+        public static final String FORBIDDEN = "Forbidden";
+        public static final String NOT_FOUND = "Not Found";
+        public static final String CONFLICT = "Conflict";
+        public static final String REQUEST_ENTITY_TOO_LARGE = "Request Entity Too Large";
+        public static final String UNSUPPORTED_MEDIA_TYPE = "Unsupported Media Type";
+        public static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
+
+    }
+
 }

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/CsrfTokenApi.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/CsrfTokenApi.java
@@ -24,10 +24,13 @@ public class CsrfTokenApi {
     private CsrfTokenApiService delegate;
 
     @GetMapping
-    @ApiOperation(value = "", notes = "Retrieves a csrf-token header ", authorizations = { @Authorization(value = "oauth2", scopes = {
+    @ApiOperation(value = "Retrieves a CSRF token header", notes = "Retrieves a csrf-token header", authorizations = { @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 204, message = "No Content") })
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "No Content"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
     public ResponseEntity<Void> getCsrfToken() {
         return delegate.getCsrfToken();
     }

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/CsrfTokenApi.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/CsrfTokenApi.java
@@ -2,8 +2,9 @@ package org.cloudfoundry.multiapps.controller.api.v1;
 
 import jakarta.inject.Inject;
 
-import org.cloudfoundry.multiapps.controller.api.CsrfTokenApiService;
+import org.cloudfoundry.multiapps.controller.api.Constants.HttpResponses;
 import org.cloudfoundry.multiapps.controller.api.Constants.Resources;
+import org.cloudfoundry.multiapps.controller.api.CsrfTokenApiService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,10 +28,10 @@ public class CsrfTokenApi {
     @ApiOperation(value = "Retrieves a CSRF token header", notes = "Retrieves a csrf-token header", authorizations = { @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 204, message = "No Content"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 204, message = HttpResponses.NO_CONTENT),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<Void> getCsrfToken() {
         return delegate.getCsrfToken();
     }

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/FilesApi.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/FilesApi.java
@@ -5,6 +5,7 @@ import java.util.List;
 import jakarta.inject.Inject;
 
 import org.cloudfoundry.multiapps.controller.api.Constants.Endpoints;
+import org.cloudfoundry.multiapps.controller.api.Constants.HttpResponses;
 import org.cloudfoundry.multiapps.controller.api.Constants.PathVariables;
 import org.cloudfoundry.multiapps.controller.api.Constants.RequestVariables;
 import org.cloudfoundry.multiapps.controller.api.Constants.Resources;
@@ -43,10 +44,10 @@ public class FilesApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = FileMetadata.class, responseContainer = "List"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = HttpResponses.OK, response = FileMetadata.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<List<FileMetadata>>
            getFiles(@ApiParam(value = "GUID of space with mtas") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                     @ApiParam(value = "Filter mtas by namespace") @RequestParam(name = RequestVariables.NAMESPACE, required = false) String namespace) {
@@ -58,13 +59,13 @@ public class FilesApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 201, message = "Created", response = FileMetadata.class),
-        @ApiResponse(code = 400, message = "Bad Request"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 413, message = "Request Entity Too Large"),
-        @ApiResponse(code = 415, message = "Unsupported Media Type"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 201, message = HttpResponses.CREATED, response = FileMetadata.class),
+        @ApiResponse(code = 400, message = HttpResponses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 413, message = HttpResponses.REQUEST_ENTITY_TOO_LARGE),
+        @ApiResponse(code = 415, message = HttpResponses.UNSUPPORTED_MEDIA_TYPE),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<FileMetadata>
            uploadFile(MultipartHttpServletRequest request,
                       @ApiParam(value = "GUID of space you wish to deploy in") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
@@ -77,12 +78,12 @@ public class FilesApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 202, message = "Accepted"),
-        @ApiResponse(code = 400, message = "Bad Request"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 413, message = "Request Entity Too Large"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 202, message = HttpResponses.ACCEPTED),
+        @ApiResponse(code = 400, message = HttpResponses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 413, message = HttpResponses.REQUEST_ENTITY_TOO_LARGE),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<Void>
            startUploadFromUrl(@ApiParam(value = "GUID of space you wish to deploy in") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                               @ApiParam(value = "file namespace") @RequestParam(name = RequestVariables.NAMESPACE, required = false) String namespace,
@@ -95,12 +96,12 @@ public class FilesApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 201, message = "Created", response = AsyncUploadResult.class),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "Not Found"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = HttpResponses.OK),
+        @ApiResponse(code = 201, message = HttpResponses.CREATED, response = AsyncUploadResult.class),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpResponses.NOT_FOUND),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<AsyncUploadResult>
            getUploadFromUrlJob(@ApiParam(value = "GUID of space you wish to deploy in") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                                @ApiParam(value = "file namespace") @RequestParam(name = RequestVariables.NAMESPACE, required = false) String namespace,

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/FilesApi.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/FilesApi.java
@@ -39,11 +39,14 @@ public class FilesApi {
     private FilesApiService delegate;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", nickname = "getMtaFiles", notes = "Retrieves all Multi-Target Application files ", response = FileMetadata.class, responseContainer = "List", authorizations = {
+    @ApiOperation(value = "Retrieve all uploaded MTA archive files in a space", nickname = "getMtaFiles", notes = "Retrieves all Multi-Target Application files", response = FileMetadata.class, responseContainer = "List", authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = FileMetadata.class, responseContainer = "List") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = FileMetadata.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
     public ResponseEntity<List<FileMetadata>>
            getFiles(@ApiParam(value = "GUID of space with mtas") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                     @ApiParam(value = "Filter mtas by namespace") @RequestParam(name = RequestVariables.NAMESPACE, required = false) String namespace) {
@@ -51,11 +54,17 @@ public class FilesApi {
     }
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", nickname = "uploadMtaFile", notes = "Uploads a Multi Target Application archive or an Extension Descriptor ", response = FileMetadata.class, authorizations = {
+    @ApiOperation(value = "Upload an MTA archive or Extension Descriptor", nickname = "uploadMtaFile", notes = "Uploads a Multi Target Application archive or an Extension Descriptor", response = FileMetadata.class, authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 201, message = "Created", response = FileMetadata.class) })
+    @ApiResponses(value = { @ApiResponse(code = 201, message = "Created", response = FileMetadata.class),
+        @ApiResponse(code = 400, message = "Bad Request"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 413, message = "Request Entity Too Large"),
+        @ApiResponse(code = 415, message = "Unsupported Media Type"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
     public ResponseEntity<FileMetadata>
            uploadFile(MultipartHttpServletRequest request,
                       @ApiParam(value = "GUID of space you wish to deploy in") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
@@ -64,11 +73,16 @@ public class FilesApi {
     }
 
     @PostMapping(path = Endpoints.ASYNC_UPLOAD, consumes = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", nickname = "startUploadFromUrl", notes = "Uploads a Multi Target Application archive or an Extension Descriptor from a remote endpoint", authorizations = {
+    @ApiOperation(value = "Start an asynchronous MTA archive upload from a URL", nickname = "startUploadFromUrl", notes = "Uploads a Multi Target Application archive or an Extension Descriptor from a remote endpoint", authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 202, message = "Accepted") })
+    @ApiResponses(value = { @ApiResponse(code = 202, message = "Accepted"),
+        @ApiResponse(code = 400, message = "Bad Request"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 413, message = "Request Entity Too Large"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
     public ResponseEntity<Void>
            startUploadFromUrl(@ApiParam(value = "GUID of space you wish to deploy in") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                               @ApiParam(value = "file namespace") @RequestParam(name = RequestVariables.NAMESPACE, required = false) String namespace,
@@ -77,12 +91,16 @@ public class FilesApi {
     }
 
     @GetMapping(path = Endpoints.ASYNC_UPLOAD_JOB, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", nickname = "getAsyncUploadJob", notes = "Gets the status of an async upload job", response = AsyncUploadResult.class, authorizations = {
+    @ApiOperation(value = "Get the status of an asynchronous URL upload job", nickname = "getAsyncUploadJob", notes = "Gets the status of an async upload job", response = AsyncUploadResult.class, authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 201, message = "Created", response = AsyncUploadResult.class) })
+        @ApiResponse(code = 201, message = "Created", response = AsyncUploadResult.class),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
     public ResponseEntity<AsyncUploadResult>
            getUploadFromUrlJob(@ApiParam(value = "GUID of space you wish to deploy in") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                                @ApiParam(value = "file namespace") @RequestParam(name = RequestVariables.NAMESPACE, required = false) String namespace,

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/InfoApi.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/InfoApi.java
@@ -26,11 +26,14 @@ public class InfoApi {
     private InfoApiService delegate;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", notes = "Retrieve information about the Deploy Service application ", response = Info.class, authorizations = {
+    @ApiOperation(value = "Retrieve information about the Deploy Service application", notes = "Retrieve information about the Deploy Service application", response = Info.class, authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Info.class) })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Info.class),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
     public ResponseEntity<Info> getInfo() {
         return delegate.getInfo();
     }

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/InfoApi.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/InfoApi.java
@@ -3,6 +3,7 @@ package org.cloudfoundry.multiapps.controller.api.v1;
 import jakarta.inject.Inject;
 
 import org.cloudfoundry.multiapps.controller.api.InfoApiService;
+import org.cloudfoundry.multiapps.controller.api.Constants.HttpResponses;
 import org.cloudfoundry.multiapps.controller.api.Constants.Resources;
 import org.cloudfoundry.multiapps.controller.api.model.Info;
 import org.springframework.http.MediaType;
@@ -30,10 +31,10 @@ public class InfoApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Info.class),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = HttpResponses.OK, response = Info.class),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<Info> getInfo() {
         return delegate.getInfo();
     }

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/MtasApi.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/MtasApi.java
@@ -33,22 +33,29 @@ public class MtasApi {
     private MtasApiService delegate;
 
     @GetMapping(path = Endpoints.MTA, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", notes = "Retrieves Multi-Target Application in a space ", response = Mta.class, authorizations = {
+    @ApiOperation(value = "Retrieve a specific deployed MTA by ID", notes = "Retrieves Multi-Target Application in a space", response = Mta.class, authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Mta.class) })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Mta.class),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
     public ResponseEntity<Mta> getMta(@ApiParam(value = "GUID of space with mtas") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                                       @ApiParam(value = "mtaID of requested mta") @PathVariable(RequestVariables.MTA_ID) String mtaId) {
         return delegate.getMta(spaceGuid, mtaId);
     }
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", notes = "Retrieves all Multi-Target Applications in a space ", response = Mta.class, responseContainer = "List", authorizations = {
+    @ApiOperation(value = "Retrieve all deployed MTAs in a space", notes = "Retrieves all Multi-Target Applications in a space", response = Mta.class, responseContainer = "List", authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Mta.class, responseContainer = "List") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Mta.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
     public ResponseEntity<List<Mta>>
            getMtas(@ApiParam(value = "GUID of space with mtas") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid) {
         return delegate.getMtas(spaceGuid);

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/MtasApi.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/MtasApi.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 
 import org.cloudfoundry.multiapps.controller.api.MtasApiService;
 import org.cloudfoundry.multiapps.controller.api.Constants.Endpoints;
+import org.cloudfoundry.multiapps.controller.api.Constants.HttpResponses;
 import org.cloudfoundry.multiapps.controller.api.Constants.PathVariables;
 import org.cloudfoundry.multiapps.controller.api.Constants.RequestVariables;
 import org.cloudfoundry.multiapps.controller.api.Constants.Resources;
@@ -37,11 +38,11 @@ public class MtasApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Mta.class),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "Not Found"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = HttpResponses.OK, response = Mta.class),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpResponses.NOT_FOUND),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<Mta> getMta(@ApiParam(value = "GUID of space with mtas") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                                       @ApiParam(value = "mtaID of requested mta") @PathVariable(RequestVariables.MTA_ID) String mtaId) {
         return delegate.getMta(spaceGuid, mtaId);
@@ -52,10 +53,10 @@ public class MtasApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Mta.class, responseContainer = "List"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = HttpResponses.OK, response = Mta.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<List<Mta>>
            getMtas(@ApiParam(value = "GUID of space with mtas") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid) {
         return delegate.getMtas(spaceGuid);

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/OperationsApi.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/OperationsApi.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.Authorization;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import org.cloudfoundry.multiapps.controller.api.Constants.Endpoints;
+import org.cloudfoundry.multiapps.controller.api.Constants.HttpResponses;
 import org.cloudfoundry.multiapps.controller.api.Constants.PathVariables;
 import org.cloudfoundry.multiapps.controller.api.Constants.QueryVariables;
 import org.cloudfoundry.multiapps.controller.api.Constants.RequestVariables;
@@ -41,12 +42,12 @@ public class OperationsApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 202, message = "Accepted"),
-        @ApiResponse(code = 400, message = "Bad Request"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "Not Found"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 202, message = HttpResponses.ACCEPTED),
+        @ApiResponse(code = 400, message = HttpResponses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpResponses.NOT_FOUND),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<Void> executeOperationAction(@ApiParam(value = "GUID of the CF space containing the operation") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                                                        @ApiParam(value = "Process ID of the MTA operation") @PathVariable(PathVariables.OPERATION_ID) String operationId,
                                                        @ApiParam(value = "Action to perform, e.g. abort or retry") @RequestParam(PathVariables.ACTION_ID) String actionId) {
@@ -58,11 +59,11 @@ public class OperationsApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Operation.class),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "Not Found"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = HttpResponses.OK, response = Operation.class),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpResponses.NOT_FOUND),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<Operation>
     getOperation(@ApiParam(value = "GUID of the CF space containing the operation") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                  @ApiParam(value = "Process ID of the MTA operation") @PathVariable(PathVariables.OPERATION_ID) String operationId,
@@ -75,11 +76,11 @@ public class OperationsApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Log.class, responseContainer = "List"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "Not Found"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = HttpResponses.OK, response = Log.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpResponses.NOT_FOUND),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<List<Log>> getOperationLogs(@ApiParam(value = "GUID of the CF space containing the operation") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                                                       @ApiParam(value = "Process ID of the MTA operation") @PathVariable(PathVariables.OPERATION_ID) String operationId) {
         return delegate.getOperationLogs(spaceGuid, operationId);
@@ -90,11 +91,11 @@ public class OperationsApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "Not Found"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = HttpResponses.OK, response = String.class),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpResponses.NOT_FOUND),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<String> getOperationLogContent(@ApiParam(value = "GUID of the CF space containing the operation") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                                                          @ApiParam(value = "Process ID of the MTA operation") @PathVariable(PathVariables.OPERATION_ID) String operationId,
                                                          @ApiParam(value = "ID of the log file to retrieve") @PathVariable(PathVariables.LOG_ID) String logId) {
@@ -106,10 +107,10 @@ public class OperationsApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Operation.class, responseContainer = "List"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = HttpResponses.OK, response = Operation.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<List<Operation>> getOperations(@ApiParam(value = "GUID of the CF space") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                                                          @ApiParam(value = "Filter operations by MTA ID") @RequestParam(name = RequestVariables.MTA_ID, required = false) String mtaId,
                                                          @ApiParam(value = "Return only the last N operations") @RequestParam(name = QueryVariables.LAST, required = false) Integer last,
@@ -122,11 +123,11 @@ public class OperationsApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 404, message = "Not Found"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = HttpResponses.OK, response = String.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpResponses.NOT_FOUND),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<List<String>> getOperationActions(@ApiParam(value = "GUID of the CF space containing the operation") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                                                             @ApiParam(value = "Process ID of the MTA operation") @PathVariable(PathVariables.OPERATION_ID) String operationId) {
         return delegate.getOperationActions(spaceGuid, operationId);
@@ -137,12 +138,12 @@ public class OperationsApi {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 202, message = "Accepted"),
-        @ApiResponse(code = 400, message = "Bad Request"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 409, message = "Conflict"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 202, message = HttpResponses.ACCEPTED),
+        @ApiResponse(code = 400, message = HttpResponses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 409, message = HttpResponses.CONFLICT),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<Operation> startOperation(@ApiParam(value = "GUID of the CF space to deploy into") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                                                     @ApiParam(value = "Operation descriptor specifying the process type and MTA parameters") @RequestBody Operation operation, HttpServletRequest httpServletRequest) {
         return delegate.startOperation(spaceGuid, operation, httpServletRequest);

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/OperationsApi.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v1/OperationsApi.java
@@ -37,85 +37,114 @@ public class OperationsApi {
     private OperationsApiService delegate;
 
     @PostMapping(path = Endpoints.OPERATION)
-    @ApiOperation(value = "", notes = "Executes a particular action over Multi-Target Application operation ", authorizations = {
+    @ApiOperation(value = "Execute an action on an MTA operation", notes = "Executes a particular action over Multi-Target Application operation", authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 202, message = "Accepted") })
-    public ResponseEntity<Void> executeOperationAction(@PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
-                                                       @PathVariable(PathVariables.OPERATION_ID) String operationId,
-                                                       @RequestParam(PathVariables.ACTION_ID) String actionId) {
+    @ApiResponses(value = { @ApiResponse(code = 202, message = "Accepted"),
+        @ApiResponse(code = 400, message = "Bad Request"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
+    public ResponseEntity<Void> executeOperationAction(@ApiParam(value = "GUID of the CF space containing the operation") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
+                                                       @ApiParam(value = "Process ID of the MTA operation") @PathVariable(PathVariables.OPERATION_ID) String operationId,
+                                                       @ApiParam(value = "Action to perform, e.g. abort or retry") @RequestParam(PathVariables.ACTION_ID) String actionId) {
         return delegate.executeOperationAction(spaceGuid, operationId, actionId);
     }
 
     @GetMapping(path = Endpoints.OPERATION, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", nickname = "getMtaOperation", notes = "Retrieves Multi-Target Application operation ", response = Operation.class, authorizations = {
+    @ApiOperation(value = "Retrieve a specific MTA operation", nickname = "getMtaOperation", notes = "Retrieves Multi-Target Application operation", response = Operation.class, authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Operation.class) })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Operation.class),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
     public ResponseEntity<Operation>
-    getOperation(@PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
-                 @PathVariable(PathVariables.OPERATION_ID) String operationId,
-                 @ApiParam(value = "Adds the specified property in the response body ") @RequestParam(name = "embed", required = false) String embed) {
+    getOperation(@ApiParam(value = "GUID of the CF space containing the operation") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
+                 @ApiParam(value = "Process ID of the MTA operation") @PathVariable(PathVariables.OPERATION_ID) String operationId,
+                 @ApiParam(value = "Adds the specified property in the response body") @RequestParam(name = "embed", required = false) String embed) {
         return delegate.getOperation(spaceGuid, operationId, embed);
     }
 
     @GetMapping(path = Endpoints.OPERATION_LOGS, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", nickname = "getMtaOperationLogs", notes = "Retrieves the logs Multi-Target Application operation ", response = Log.class, responseContainer = "List", authorizations = {
+    @ApiOperation(value = "List log files for an MTA operation", nickname = "getMtaOperationLogs", notes = "Retrieves the logs Multi-Target Application operation", response = Log.class, responseContainer = "List", authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Log.class, responseContainer = "List") })
-    public ResponseEntity<List<Log>> getOperationLogs(@PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
-                                                      @PathVariable(PathVariables.OPERATION_ID) String operationId) {
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Log.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
+    public ResponseEntity<List<Log>> getOperationLogs(@ApiParam(value = "GUID of the CF space containing the operation") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
+                                                      @ApiParam(value = "Process ID of the MTA operation") @PathVariable(PathVariables.OPERATION_ID) String operationId) {
         return delegate.getOperationLogs(spaceGuid, operationId);
     }
 
     @GetMapping(path = Endpoints.OPERATION_LOG_CONTENT, produces = MediaType.TEXT_PLAIN_VALUE)
-    @ApiOperation(value = "", nickname = "getMtaOperationLogContent", notes = "Retrieves the log content for Multi-Target Application operation ", response = String.class, authorizations = {
+    @ApiOperation(value = "Retrieve the content of a specific operation log", nickname = "getMtaOperationLogContent", notes = "Retrieves the log content for Multi-Target Application operation", response = String.class, authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class) })
-    public ResponseEntity<String> getOperationLogContent(@PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
-                                                         @PathVariable(PathVariables.OPERATION_ID) String operationId,
-                                                         @PathVariable(PathVariables.LOG_ID) String logId) {
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
+    public ResponseEntity<String> getOperationLogContent(@ApiParam(value = "GUID of the CF space containing the operation") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
+                                                         @ApiParam(value = "Process ID of the MTA operation") @PathVariable(PathVariables.OPERATION_ID) String operationId,
+                                                         @ApiParam(value = "ID of the log file to retrieve") @PathVariable(PathVariables.LOG_ID) String logId) {
         return delegate.getOperationLogContent(spaceGuid, operationId, logId);
     }
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", nickname = "getMtaOperations", notes = "Retrieves Multi-Target Application operations ", response = Operation.class, responseContainer = "List", authorizations = {
+    @ApiOperation(value = "List MTA operations in a space", nickname = "getMtaOperations", notes = "Retrieves Multi-Target Application operations", response = Operation.class, responseContainer = "List", authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Operation.class, responseContainer = "List") })
-    public ResponseEntity<List<Operation>> getOperations(@PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
-                                                         @RequestParam(name = RequestVariables.MTA_ID, required = false) String mtaId,
-                                                         @RequestParam(name = QueryVariables.LAST, required = false) Integer last,
-                                                         @RequestParam(name = QueryVariables.STATE, required = false) List<String> states) {
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Operation.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
+    public ResponseEntity<List<Operation>> getOperations(@ApiParam(value = "GUID of the CF space") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
+                                                         @ApiParam(value = "Filter operations by MTA ID") @RequestParam(name = RequestVariables.MTA_ID, required = false) String mtaId,
+                                                         @ApiParam(value = "Return only the last N operations") @RequestParam(name = QueryVariables.LAST, required = false) Integer last,
+                                                         @ApiParam(value = "Filter operations by state, e.g. RUNNING, FINISHED, ERROR, ABORTED") @RequestParam(name = QueryVariables.STATE, required = false) List<String> states) {
         return delegate.getOperations(spaceGuid, mtaId, states, last);
     }
 
     @GetMapping(path = Endpoints.OPERATION_ACTIONS, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", notes = "Retrieves available actions for Multi-Target Application operation ", response = String.class, responseContainer = "List", authorizations = {
+    @ApiOperation(value = "List available actions for an MTA operation", notes = "Retrieves available actions for Multi-Target Application operation", response = String.class, responseContainer = "List", authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List") })
-    public ResponseEntity<List<String>> getOperationActions(@PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
-                                                            @PathVariable(PathVariables.OPERATION_ID) String operationId) {
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
+    public ResponseEntity<List<String>> getOperationActions(@ApiParam(value = "GUID of the CF space containing the operation") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
+                                                            @ApiParam(value = "Process ID of the MTA operation") @PathVariable(PathVariables.OPERATION_ID) String operationId) {
         return delegate.getOperationActions(spaceGuid, operationId);
     }
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", nickname = "startMtaOperation", notes = "Starts execution of a Multi-Target Application operation ", authorizations = {
+    @ApiOperation(value = "Start a new MTA operation (deploy, undeploy, blue-green deploy)", nickname = "startMtaOperation", notes = "Starts execution of a Multi-Target Application operation", authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 202, message = "Accepted") })
-    public ResponseEntity<Operation> startOperation(@PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
-                                                    @RequestBody Operation operation, HttpServletRequest httpServletRequest) {
+    @ApiResponses(value = { @ApiResponse(code = 202, message = "Accepted"),
+        @ApiResponse(code = 400, message = "Bad Request"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 409, message = "Conflict"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
+    public ResponseEntity<Operation> startOperation(@ApiParam(value = "GUID of the CF space to deploy into") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
+                                                    @ApiParam(value = "Operation descriptor specifying the process type and MTA parameters") @RequestBody Operation operation, HttpServletRequest httpServletRequest) {
         return delegate.startOperation(spaceGuid, operation, httpServletRequest);
     }
 

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v2/MtasApiV2.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v2/MtasApiV2.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import jakarta.inject.Inject;
 
+import org.cloudfoundry.multiapps.controller.api.Constants.HttpResponses;
 import org.cloudfoundry.multiapps.controller.api.Constants.PathVariables;
 import org.cloudfoundry.multiapps.controller.api.Constants.RequestVariables;
 import org.cloudfoundry.multiapps.controller.api.Constants.Resources;
@@ -37,10 +38,10 @@ public class MtasApiV2 {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Mta.class, responseContainer = "List"),
-        @ApiResponse(code = 401, message = "Unauthorized"),
-        @ApiResponse(code = 403, message = "Forbidden"),
-        @ApiResponse(code = 500, message = "Internal Server Error") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = HttpResponses.OK, response = Mta.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = HttpResponses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpResponses.FORBIDDEN),
+        @ApiResponse(code = 500, message = HttpResponses.INTERNAL_SERVER_ERROR) })
     public ResponseEntity<List<Mta>>
            getMtas(@ApiParam(value = "GUID of space with mtas") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                    @ApiParam(value = "Filter mtas by namespace") @RequestParam(name = RequestVariables.NAMESPACE, required = false) String namespace,

--- a/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v2/MtasApiV2.java
+++ b/multiapps-controller-api/src/main/java/org/cloudfoundry/multiapps/controller/api/v2/MtasApiV2.java
@@ -33,11 +33,14 @@ public class MtasApiV2 {
     private MtasApiService delegate;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "", notes = "Retrieves all Multi-Target Applications in a given space and namespace", response = Mta.class, responseContainer = "List", authorizations = {
+    @ApiOperation(value = "Retrieve all deployed MTAs in a space, filtered by namespace or name", notes = "Retrieves all Multi-Target Applications in a given space and namespace", response = Mta.class, responseContainer = "List", authorizations = {
         @Authorization(value = "oauth2", scopes = {
 
         }) }, tags = {})
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Mta.class, responseContainer = "List") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Mta.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = "Unauthorized"),
+        @ApiResponse(code = 403, message = "Forbidden"),
+        @ApiResponse(code = 500, message = "Internal Server Error") })
     public ResponseEntity<List<Mta>>
            getMtas(@ApiParam(value = "GUID of space with mtas") @PathVariable(PathVariables.SPACE_GUID) String spaceGuid,
                    @ApiParam(value = "Filter mtas by namespace") @RequestParam(name = RequestVariables.NAMESPACE, required = false) String namespace,

--- a/multiapps-controller-api/src/main/resources/mtarest.yaml
+++ b/multiapps-controller-api/src/main/resources/mtarest.yaml
@@ -110,10 +110,6 @@ paths:
         required: false
         type: "string"
       responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/FileMetadata"
         "201":
           description: "Created"
           schema:
@@ -343,10 +339,6 @@ paths:
         schema:
           $ref: "#/definitions/Operation"
       responses:
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Operation"
         "202":
           description: "Accepted"
         "400":

--- a/multiapps-controller-api/src/main/resources/mtarest.yaml
+++ b/multiapps-controller-api/src/main/resources/mtarest.yaml
@@ -1,7 +1,15 @@
 ---
 swagger: "2.0"
 info:
-  description: "This is the API of the Cloud Foundry MultiApps Controller"
+  description: "This is the API of the Cloud Foundry MultiApps Controller.\n\n## Typical\
+    \ deploy sequence\n\nStep 1 (optional) — Obtain a CSRF token:\n  GET /api/v1/csrf-token\n\
+    \nStep 2 — Upload the MTA archive:\n  POST /api/v1/spaces/{spaceGuid}/files\n\n\
+    Step 3 — Start a deploy operation:\n  POST /api/v1/spaces/{spaceGuid}/operations\n\
+    \  Request body: Operation object with processType=DEPLOY and mtaId.\n\nStep 4\
+    \ — Poll operation status:\n  GET /api/v1/spaces/{spaceGuid}/operations/{operationId}\n\
+    \  Repeat until state is one of: FINISHED, ERROR, ABORTED, ACTION_REQUIRED.\n\n\
+    Step 5 (optional) — Execute an action:\n  POST /api/v1/spaces/{spaceGuid}/operations/{operationId}?actionId=abort|retry\n\
+    \  Use when state is ACTION_REQUIRED or to abort a running operation."
   version: "1.4.0"
   title: "MTA REST API"
   contact: {}
@@ -13,34 +21,46 @@ schemes:
 paths:
   /api/v1/csrf-token:
     get:
-      summary: ""
-      description: "Retrieves a csrf-token header "
+      summary: "Retrieves a CSRF token header"
+      description: "Retrieves a csrf-token header"
       operationId: "getCsrfToken"
       parameters: []
       responses:
-        204:
+        "204":
           description: "No Content"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
   /api/v1/info:
     get:
-      summary: ""
-      description: "Retrieve information about the Deploy Service application "
+      summary: "Retrieve information about the Deploy Service application"
+      description: "Retrieve information about the Deploy Service application"
       operationId: "getInfo"
       produces:
       - "application/json"
       parameters: []
       responses:
-        200:
+        "200":
           description: "OK"
           schema:
             $ref: "#/definitions/Info"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
   /api/v1/spaces/{spaceGuid}/files:
     get:
-      summary: ""
-      description: "Retrieves all Multi-Target Application files "
+      summary: "Retrieve all uploaded MTA archive files in a space"
+      description: "Retrieves all Multi-Target Application files"
       operationId: "getMtaFiles"
       produces:
       - "application/json"
@@ -56,17 +76,23 @@ paths:
         required: false
         type: "string"
       responses:
-        200:
+        "200":
           description: "OK"
           schema:
             type: "array"
             items:
               $ref: "#/definitions/FileMetadata"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
     post:
-      summary: ""
-      description: "Uploads a Multi Target Application archive or an Extension Descriptor "
+      summary: "Upload an MTA archive or Extension Descriptor"
+      description: "Uploads a Multi Target Application archive or an Extension Descriptor"
       operationId: "uploadMtaFile"
       consumes:
       - "multipart/form-data"
@@ -84,19 +110,31 @@ paths:
         required: false
         type: "string"
       responses:
-        200:
+        "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/FileMetadata"
-        201:
+        "201":
           description: "Created"
           schema:
             $ref: "#/definitions/FileMetadata"
+        "400":
+          description: "Bad Request"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "413":
+          description: "Request Entity Too Large"
+        "415":
+          description: "Unsupported Media Type"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
   /api/v1/spaces/{spaceGuid}/files/async:
     post:
-      summary: ""
+      summary: "Start an asynchronous MTA archive upload from a URL"
       description: "Uploads a Multi Target Application archive or an Extension Descriptor\
         \ from a remote endpoint"
       operationId: "startUploadFromUrl"
@@ -120,13 +158,23 @@ paths:
         schema:
           $ref: "#/definitions/FileUrl"
       responses:
-        202:
+        "202":
           description: "Accepted"
+        "400":
+          description: "Bad Request"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "413":
+          description: "Request Entity Too Large"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
   /api/v1/spaces/{spaceGuid}/files/jobs/{jobId}:
     get:
-      summary: ""
+      summary: "Get the status of an asynchronous URL upload job"
       description: "Gets the status of an async upload job"
       operationId: "getAsyncUploadJob"
       produces:
@@ -148,20 +196,28 @@ paths:
         required: true
         type: "string"
       responses:
-        200:
+        "200":
           description: "OK"
           schema:
             $ref: "#/definitions/AsyncUploadResult"
-        201:
+        "201":
           description: "Created"
           schema:
             $ref: "#/definitions/AsyncUploadResult"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "404":
+          description: "Not Found"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
   /api/v1/spaces/{spaceGuid}/mtas:
     get:
-      summary: ""
-      description: "Retrieves all Multi-Target Applications in a space "
+      summary: "Retrieve all deployed MTAs in a space"
+      description: "Retrieves all Multi-Target Applications in a space"
       operationId: "getMtas"
       produces:
       - "application/json"
@@ -172,18 +228,24 @@ paths:
         required: true
         type: "string"
       responses:
-        200:
+        "200":
           description: "OK"
           schema:
             type: "array"
             items:
               $ref: "#/definitions/Mta"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
   /api/v1/spaces/{spaceGuid}/mtas/{mtaId}:
     get:
-      summary: ""
-      description: "Retrieves Multi-Target Application in a space "
+      summary: "Retrieve a specific deployed MTA by ID"
+      description: "Retrieves Multi-Target Application in a space"
       operationId: "getMta"
       produces:
       - "application/json"
@@ -199,52 +261,70 @@ paths:
         required: true
         type: "string"
       responses:
-        200:
+        "200":
           description: "OK"
           schema:
             $ref: "#/definitions/Mta"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "404":
+          description: "Not Found"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
   /api/v1/spaces/{spaceGuid}/operations:
     get:
-      summary: ""
-      description: "Retrieves Multi-Target Application operations "
+      summary: "List MTA operations in a space"
+      description: "Retrieves Multi-Target Application operations"
       operationId: "getMtaOperations"
       produces:
       - "application/json"
       parameters:
       - name: "spaceGuid"
         in: "path"
+        description: "GUID of the CF space"
         required: true
         type: "string"
       - name: "mtaId"
         in: "query"
+        description: "Filter operations by MTA ID"
         required: false
         type: "string"
       - name: "last"
         in: "query"
+        description: "Return only the last N operations"
         required: false
         type: "integer"
         format: "int32"
       - name: "state"
         in: "query"
+        description: "Filter operations by state, e.g. RUNNING, FINISHED, ERROR, ABORTED"
         required: false
         type: "array"
         items:
           type: "string"
         collectionFormat: "multi"
       responses:
-        200:
+        "200":
           description: "OK"
           schema:
             type: "array"
             items:
               $ref: "#/definitions/Operation"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
     post:
-      summary: ""
-      description: "Starts execution of a Multi-Target Application operation "
+      summary: "Start a new MTA operation (deploy, undeploy, blue-green deploy)"
+      description: "Starts execution of a Multi-Target Application operation"
       operationId: "startMtaOperation"
       consumes:
       - "application/json"
@@ -253,147 +333,213 @@ paths:
       parameters:
       - name: "spaceGuid"
         in: "path"
+        description: "GUID of the CF space to deploy into"
         required: true
         type: "string"
       - in: "body"
         name: "body"
+        description: "Operation descriptor specifying the process type and MTA parameters"
         required: false
         schema:
           $ref: "#/definitions/Operation"
       responses:
-        200:
+        "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/Operation"
-        202:
+        "202":
           description: "Accepted"
+        "400":
+          description: "Bad Request"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "409":
+          description: "Conflict"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
   /api/v1/spaces/{spaceGuid}/operations/{operationId}:
     get:
-      summary: ""
-      description: "Retrieves Multi-Target Application operation "
+      summary: "Retrieve a specific MTA operation"
+      description: "Retrieves Multi-Target Application operation"
       operationId: "getMtaOperation"
       produces:
       - "application/json"
       parameters:
       - name: "spaceGuid"
         in: "path"
+        description: "GUID of the CF space containing the operation"
         required: true
         type: "string"
       - name: "operationId"
         in: "path"
+        description: "Process ID of the MTA operation"
         required: true
         type: "string"
       - name: "embed"
         in: "query"
-        description: "Adds the specified property in the response body "
+        description: "Adds the specified property in the response body"
         required: false
         type: "string"
       responses:
-        200:
+        "200":
           description: "OK"
           schema:
             $ref: "#/definitions/Operation"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "404":
+          description: "Not Found"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
     post:
-      summary: ""
-      description: "Executes a particular action over Multi-Target Application operation "
+      summary: "Execute an action on an MTA operation"
+      description: "Executes a particular action over Multi-Target Application operation"
       operationId: "executeOperationAction"
       parameters:
       - name: "spaceGuid"
         in: "path"
+        description: "GUID of the CF space containing the operation"
         required: true
         type: "string"
       - name: "operationId"
         in: "path"
+        description: "Process ID of the MTA operation"
         required: true
         type: "string"
       - name: "actionId"
         in: "query"
+        description: "Action to perform, e.g. abort or retry"
         required: true
         type: "string"
       responses:
-        202:
+        "202":
           description: "Accepted"
+        "400":
+          description: "Bad Request"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "404":
+          description: "Not Found"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
   /api/v1/spaces/{spaceGuid}/operations/{operationId}/actions:
     get:
-      summary: ""
-      description: "Retrieves available actions for Multi-Target Application operation "
+      summary: "List available actions for an MTA operation"
+      description: "Retrieves available actions for Multi-Target Application operation"
       operationId: "getOperationActions"
       produces:
       - "application/json"
       parameters:
       - name: "spaceGuid"
         in: "path"
+        description: "GUID of the CF space containing the operation"
         required: true
         type: "string"
       - name: "operationId"
         in: "path"
+        description: "Process ID of the MTA operation"
         required: true
         type: "string"
       responses:
-        200:
+        "200":
           description: "OK"
           schema:
             type: "array"
             items:
               type: "string"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "404":
+          description: "Not Found"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
   /api/v1/spaces/{spaceGuid}/operations/{operationId}/logs:
     get:
-      summary: ""
-      description: "Retrieves the logs Multi-Target Application operation "
+      summary: "List log files for an MTA operation"
+      description: "Retrieves the logs Multi-Target Application operation"
       operationId: "getMtaOperationLogs"
       produces:
       - "application/json"
       parameters:
       - name: "spaceGuid"
         in: "path"
+        description: "GUID of the CF space containing the operation"
         required: true
         type: "string"
       - name: "operationId"
         in: "path"
+        description: "Process ID of the MTA operation"
         required: true
         type: "string"
       responses:
-        200:
+        "200":
           description: "OK"
           schema:
             type: "array"
             items:
               $ref: "#/definitions/Log"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "404":
+          description: "Not Found"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
   /api/v1/spaces/{spaceGuid}/operations/{operationId}/logs/{logId}/content:
     get:
-      summary: ""
-      description: "Retrieves the log content for Multi-Target Application operation "
+      summary: "Retrieve the content of a specific operation log"
+      description: "Retrieves the log content for Multi-Target Application operation"
       operationId: "getMtaOperationLogContent"
       produces:
       - "text/plain"
       parameters:
       - name: "spaceGuid"
         in: "path"
+        description: "GUID of the CF space containing the operation"
         required: true
         type: "string"
       - name: "operationId"
         in: "path"
+        description: "Process ID of the MTA operation"
         required: true
         type: "string"
       - name: "logId"
         in: "path"
+        description: "ID of the log file to retrieve"
         required: true
         type: "string"
       responses:
-        200:
+        "200":
           description: "OK"
           schema:
             type: "string"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "404":
+          description: "Not Found"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
 securityDefinitions:

--- a/multiapps-controller-api/src/main/resources/mtarest_v2.yaml
+++ b/multiapps-controller-api/src/main/resources/mtarest_v2.yaml
@@ -13,7 +13,7 @@ schemes:
 paths:
   /api/v2/spaces/{spaceGuid}/mtas:
     get:
-      summary: ""
+      summary: "Retrieve all deployed MTAs in a space, filtered by namespace or name"
       description: "Retrieves all Multi-Target Applications in a given space and namespace"
       operationId: "getMtas"
       produces:
@@ -35,12 +35,18 @@ paths:
         required: false
         type: "string"
       responses:
-        200:
+        "200":
           description: "OK"
           schema:
             type: "array"
             items:
               $ref: "#/definitions/Mta"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Forbidden"
+        "500":
+          description: "Internal Server Error"
       security:
       - oauth2: []
 securityDefinitions:


### PR DESCRIPTION
## Summary

Improves the generated Swagger/OpenAPI documentation for the MultiApps Controller REST API to better align with API best practices and validator expectations. The change is documentation-focused: it enriches Swagger annotations on the REST facade classes, adds a YAML post-processing build step, and regenerates the checked-in `mtarest.yaml` / `mtarest_v2.yaml` specs. No executable Java behavior changes.

## Changes

- **REST facade annotations** — Added and expanded operation summaries, parameter descriptions, and the full set of possible error response codes/descriptions across the v1 and v2 API classes:
  - `CsrfTokenApi`, `FilesApi`, `InfoApi`, `MtasApi`, `OperationsApi` (v1)
  - `MtasApiV2` (v2)
- **API description** — Extended the top-level API description with a step-by-step example of the typical deploy sequence (obtain CSRF token -> upload archive -> start deploy operation -> poll status -> execute action).
- **Build step (`multiapps-controller-api/pom.xml`)** — Added a `maven-antrun-plugin` execution that quotes integer response-code keys (e.g. `200:` -> `"200":`) in the generated YAML, so the emitted spec uses string keys as required by the OpenAPI/Swagger 2.0 spec.
- **Regenerated specs** — Updated `src/main/resources/mtarest.yaml` and `mtarest_v2.yaml` to reflect the annotation and post-processing changes.

## Testing

`mvn -pl multiapps-controller-api -o compile` passes. No unit tests were added or modified: the change is documentation-only (Swagger annotations, a YAML post-processing build step, and regenerated YAML) with no new or modified executable Java behavior to cover.

JIRA:LMCROSSITXSADEPLOY-3166