### PR TITLE
Improve wait time in retry logic for CC calls

### DIFF
--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/Messages.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/Messages.java
@@ -5,7 +5,7 @@ public class Messages {
     // INFO messages
     public static final String WAITING_MS_BEFORE_RETRYING_WITH_TIMEOUT_OF_MS = "Waiting: {} ms before retrying with timeout of: {} ms";
     public static final String RATE_LIMITED_BY_CC_WAITING_S = "CC returned 429 with Retry-After: {} s. Waiting {} s (capped) before retrying.";
-    public static final String RATE_LIMITED_BY_CC_NO_HEADER_WAITING_S = "CC returned 429 without Retry-After header. Waiting {} ms before retrying.";
+    public static final String RATE_LIMITED_BY_CC_NO_HEADER_WAITING_MS = "CC returned 429 without Retry-After header. Waiting {} ms before retrying.";
     public static final String RANDOM_WAIT_BEFORE_RETRY_S = "Waiting {} ms (randomized) before retrying failed CC operation.";
 
 }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/Messages.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/Messages.java
@@ -6,6 +6,6 @@ public class Messages {
     public static final String WAITING_MS_BEFORE_RETRYING_WITH_TIMEOUT_OF_MS = "Waiting: {} ms before retrying with timeout of: {} ms";
     public static final String RATE_LIMITED_BY_CC_WAITING_S = "CC returned 429 with Retry-After: {} s. Waiting {} s (capped) before retrying.";
     public static final String RATE_LIMITED_BY_CC_NO_HEADER_WAITING_MS = "CC returned 429 without Retry-After header. Waiting {} ms before retrying.";
-    public static final String RANDOM_WAIT_BEFORE_RETRY_S = "Waiting {} ms (randomized) before retrying failed CC operation.";
+    public static final String RANDOM_WAIT_BEFORE_RETRY_MS = "Waiting {} ms (randomized) before retrying failed CC operation.";
 
 }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/Messages.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/Messages.java
@@ -4,5 +4,8 @@ public class Messages {
 
     // INFO messages
     public static final String WAITING_MS_BEFORE_RETRYING_WITH_TIMEOUT_OF_MS = "Waiting: {} ms before retrying with timeout of: {} ms";
+    public static final String RATE_LIMITED_BY_CC_WAITING_S = "CC returned 429 with Retry-After: {} s. Waiting {} s (capped) before retrying.";
+    public static final String RATE_LIMITED_BY_CC_NO_HEADER_WAITING_S = "CC returned 429 without Retry-After header. Waiting {} ms before retrying.";
+    public static final String RANDOM_WAIT_BEFORE_RETRY_S = "Waiting {} ms (randomized) before retrying failed CC operation.";
 
 }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/CloudOperationException.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/CloudOperationException.java
@@ -8,6 +8,7 @@ public class CloudOperationException extends CloudException {
     private final HttpStatus statusCode;
     private final String statusText;
     private final String description;
+    private final Long retryAfterSeconds;
 
     public CloudOperationException(HttpStatus statusCode) {
         this(statusCode, statusCode.getReasonPhrase());
@@ -22,10 +23,16 @@ public class CloudOperationException extends CloudException {
     }
 
     public CloudOperationException(HttpStatus statusCode, String statusText, String description, Throwable cause) {
+        this(statusCode, statusText, description, cause, null);
+    }
+
+    public CloudOperationException(HttpStatus statusCode, String statusText, String description, Throwable cause,
+                                   Long retryAfterSeconds) {
         super(getExceptionMessage(statusCode, statusText, description), cause);
         this.statusCode = statusCode;
         this.statusText = statusText;
         this.description = description;
+        this.retryAfterSeconds = retryAfterSeconds;
     }
 
     private static String getExceptionMessage(HttpStatus statusCode, String statusText, String description) {
@@ -45,6 +52,10 @@ public class CloudOperationException extends CloudException {
 
     public String getDescription() {
         return description;
+    }
+
+    public Long getRetryAfterSeconds() {
+        return retryAfterSeconds;
     }
 
 }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandler.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandler.java
@@ -47,7 +47,7 @@ public class CloudControllerResponseErrorHandler extends DefaultResponseErrorHan
         }
         try {
             long parsed = Long.parseLong(headerValue);
-            return parsed > 0 ? parsed : null;
+            return parsed >= 0 ? parsed : null;
         } catch (NumberFormatException _) {
             return null;
         }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandler.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandler.java
@@ -45,7 +45,8 @@ public class CloudControllerResponseErrorHandler extends DefaultResponseErrorHan
             return null;
         }
         try {
-            return Long.parseLong(headerValue);
+            long parsed = Long.parseLong(headerValue);
+            return parsed > 0 ? parsed : null;
         } catch (NumberFormatException e) {
             return null;
         }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandler.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandler.java
@@ -1,17 +1,18 @@
 package org.cloudfoundry.multiapps.controller.client.facade.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.cloudfoundry.multiapps.controller.client.facade.CloudOperationException;
-import org.cloudfoundry.multiapps.controller.client.facade.util.CloudUtil;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.web.client.DefaultResponseErrorHandler;
-import org.springframework.web.client.RestClientException;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cloudfoundry.multiapps.controller.client.facade.CloudOperationException;
+import org.cloudfoundry.multiapps.controller.client.facade.util.CloudUtil;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.RestClientException;
 
 public class CloudControllerResponseErrorHandler extends DefaultResponseErrorHandler {
 
@@ -40,14 +41,14 @@ public class CloudControllerResponseErrorHandler extends DefaultResponseErrorHan
             return null;
         }
         String headerValue = response.getHeaders()
-                                     .getFirst(org.springframework.http.HttpHeaders.RETRY_AFTER);
+                                     .getFirst(HttpHeaders.RETRY_AFTER);
         if (headerValue == null) {
             return null;
         }
         try {
             long parsed = Long.parseLong(headerValue);
             return parsed > 0 ? parsed : null;
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException _) {
             return null;
         }
     }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandler.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandler.java
@@ -19,6 +19,7 @@ public class CloudControllerResponseErrorHandler extends DefaultResponseErrorHan
         HttpStatus statusCode = HttpStatus.valueOf(response.getStatusCode()
                                                            .value());
         String statusText = response.getStatusText();
+        Long retryAfterSeconds = extractRetryAfterSeconds(response, statusCode);
 
         ObjectMapper mapper = new ObjectMapper(); // can reuse, share globally
 
@@ -26,12 +27,28 @@ public class CloudControllerResponseErrorHandler extends DefaultResponseErrorHan
             try {
                 @SuppressWarnings("unchecked") Map<String, Object> responseBody = mapper.readValue(response.getBody(), Map.class);
                 String description = getTrimmedDescription(responseBody);
-                return new CloudOperationException(statusCode, statusText, description);
+                return new CloudOperationException(statusCode, statusText, description, null, retryAfterSeconds);
             } catch (IOException e) {
                 // Fall through. Handled below.
             }
         }
-        return new CloudOperationException(statusCode, statusText);
+        return new CloudOperationException(statusCode, statusText, null, null, retryAfterSeconds);
+    }
+
+    private static Long extractRetryAfterSeconds(ClientHttpResponse response, HttpStatus statusCode) {
+        if (statusCode != HttpStatus.TOO_MANY_REQUESTS) {
+            return null;
+        }
+        String headerValue = response.getHeaders()
+                                     .getFirst(org.springframework.http.HttpHeaders.RETRY_AFTER);
+        if (headerValue == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(headerValue);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     private static String getTrimmedDescription(Map<String, Object> responseBody) {

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
+import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 import org.apache.commons.collections4.SetUtils;
@@ -42,6 +43,9 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
 
     private Set<HttpStatus> additionalStatusesToIgnore = Collections.emptySet();
     private LongConsumer sleeper = MiscUtil::sleep;
+    private LongSupplier randomDelaySupplier = () -> ThreadLocalRandom.current()
+                                                                       .nextLong(RANDOM_RETRY_MIN_WAIT_IN_MILLIS,
+                                                                                 RANDOM_RETRY_MAX_WAIT_IN_MILLIS + 1);
 
     @Override
     public ResilientCloudOperationExecutor withRetryCount(long retryCount) {
@@ -60,6 +64,11 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
 
     ResilientCloudOperationExecutor withSleeper(LongConsumer sleeper) {
         this.sleeper = sleeper;
+        return this;
+    }
+
+    ResilientCloudOperationExecutor withRandomDelaySupplier(LongSupplier randomDelaySupplier) {
+        this.randomDelaySupplier = randomDelaySupplier;
         return this;
     }
 
@@ -132,8 +141,7 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
             }
         }
         if (attemptIndex >= 2) {
-            long waitMillis = ThreadLocalRandom.current()
-                                               .nextLong(RANDOM_RETRY_MIN_WAIT_IN_MILLIS, RANDOM_RETRY_MAX_WAIT_IN_MILLIS + 1);
+            long waitMillis = randomDelaySupplier.getAsLong();
             LOGGER.info(Messages.RANDOM_WAIT_BEFORE_RETRY_S, waitMillis);
             return waitMillis;
         }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
@@ -131,7 +131,7 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
         }
         if (attemptIndex >= 2) {
             long waitMillis = randomDelaySupplier.getAsLong();
-            LOGGER.info(Messages.RANDOM_WAIT_BEFORE_RETRY_S, waitMillis);
+            LOGGER.info(Messages.RANDOM_WAIT_BEFORE_RETRY_MS, waitMillis);
             return waitMillis;
         }
         return waitTimeBetweenRetriesInMillis;

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
@@ -44,8 +44,8 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
     private Set<HttpStatus> additionalStatusesToIgnore = Collections.emptySet();
     private LongConsumer sleeper = MiscUtil::sleep;
     private LongSupplier randomDelaySupplier = () -> ThreadLocalRandom.current()
-                                                                       .nextLong(RANDOM_RETRY_MIN_WAIT_IN_MILLIS,
-                                                                                 RANDOM_RETRY_MAX_WAIT_IN_MILLIS + 1);
+                                                                      .nextLong(RANDOM_RETRY_MIN_WAIT_IN_MILLIS,
+                                                                                RANDOM_RETRY_MAX_WAIT_IN_MILLIS + 1);
 
     @Override
     public ResilientCloudOperationExecutor withRetryCount(long retryCount) {
@@ -126,19 +126,8 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
     }
 
     private long computeWaitMillis(RuntimeException e, long attemptIndex) {
-        if (e instanceof CloudOperationException) {
-            CloudOperationException cloudException = (CloudOperationException) e;
-            if (cloudException.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
-                Long retryAfterSeconds = cloudException.getRetryAfterSeconds();
-                if (retryAfterSeconds != null) {
-                    long cappedSeconds = Math.max(1L, Math.min(retryAfterSeconds, RATE_LIMIT_RETRY_AFTER_CAP_IN_SECONDS));
-                    long waitMillis = cappedSeconds * 1000L;
-                    LOGGER.info(Messages.RATE_LIMITED_BY_CC_WAITING_S, retryAfterSeconds, cappedSeconds);
-                    return waitMillis;
-                }
-                LOGGER.info(Messages.RATE_LIMITED_BY_CC_NO_HEADER_WAITING_S, RATE_LIMIT_FALLBACK_WAIT_IN_MILLIS);
-                return RATE_LIMIT_FALLBACK_WAIT_IN_MILLIS;
-            }
+        if (isRateLimitException(e)) {
+            return computeRateLimitWaitMillis((CloudOperationException) e);
         }
         if (attemptIndex >= 2) {
             long waitMillis = randomDelaySupplier.getAsLong();
@@ -146,6 +135,22 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
             return waitMillis;
         }
         return waitTimeBetweenRetriesInMillis;
+    }
+
+    private boolean isRateLimitException(RuntimeException e) {
+        return e instanceof CloudOperationException cloudException
+            && cloudException.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS;
+    }
+
+    private long computeRateLimitWaitMillis(CloudOperationException e) {
+        Long retryAfterSeconds = e.getRetryAfterSeconds();
+        if (retryAfterSeconds == null) {
+            LOGGER.info(Messages.RATE_LIMITED_BY_CC_NO_HEADER_WAITING_S, RATE_LIMIT_FALLBACK_WAIT_IN_MILLIS);
+            return RATE_LIMIT_FALLBACK_WAIT_IN_MILLIS;
+        }
+        long cappedSeconds = Math.max(1L, Math.min(retryAfterSeconds, RATE_LIMIT_RETRY_AFTER_CAP_IN_SECONDS));
+        LOGGER.info(Messages.RATE_LIMITED_BY_CC_WAITING_S, retryAfterSeconds, cappedSeconds);
+        return cappedSeconds * 1000L;
     }
 
     private boolean shouldRetry(CloudOperationException e) {

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
@@ -131,7 +131,7 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
             if (cloudException.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
                 Long retryAfterSeconds = cloudException.getRetryAfterSeconds();
                 if (retryAfterSeconds != null) {
-                    long cappedSeconds = Math.min(retryAfterSeconds, RATE_LIMIT_RETRY_AFTER_CAP_IN_SECONDS);
+                    long cappedSeconds = Math.max(1L, Math.min(retryAfterSeconds, RATE_LIMIT_RETRY_AFTER_CAP_IN_SECONDS));
                     long waitMillis = cappedSeconds * 1000L;
                     LOGGER.info(Messages.RATE_LIMITED_BY_CC_WAITING_S, retryAfterSeconds, cappedSeconds);
                     return waitMillis;

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
@@ -7,7 +7,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
+import java.util.function.LongConsumer;
+import java.util.function.Supplier;
 
 import org.apache.commons.collections4.SetUtils;
 import org.cloudfoundry.multiapps.common.util.MiscUtil;
@@ -23,7 +26,8 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
 
     private static final Set<HttpStatus> DEFAULT_STATUSES_TO_IGNORE = Set.of(HttpStatus.GATEWAY_TIMEOUT, HttpStatus.REQUEST_TIMEOUT,
                                                                              HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.BAD_GATEWAY,
-                                                                             HttpStatus.SERVICE_UNAVAILABLE);
+                                                                             HttpStatus.SERVICE_UNAVAILABLE,
+                                                                             HttpStatus.TOO_MANY_REQUESTS);
 
     private static final int DEFAULT_TIMEOUT_RETRY_WAIT_TIME_IN_MILLIS = 30 * 1000; // 30 seconds
 
@@ -31,7 +35,13 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
                                                                                            Duration.ofMinutes(8), 3,
                                                                                            Duration.ofMinutes(15));
 
+    private static final long RATE_LIMIT_RETRY_AFTER_CAP_IN_SECONDS = 120L;
+    private static final long RATE_LIMIT_FALLBACK_WAIT_IN_MILLIS = 60_000L;
+    private static final long RANDOM_RETRY_MIN_WAIT_IN_MILLIS = 30_000L;
+    private static final long RANDOM_RETRY_MAX_WAIT_IN_MILLIS = 90_000L;
+
     private Set<HttpStatus> additionalStatusesToIgnore = Collections.emptySet();
+    private LongConsumer sleeper = MiscUtil::sleep;
 
     @Override
     public ResilientCloudOperationExecutor withRetryCount(long retryCount) {
@@ -46,6 +56,25 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
     public ResilientCloudOperationExecutor withStatusesToIgnore(HttpStatus... statusesToIgnore) {
         this.additionalStatusesToIgnore = new HashSet<>(Arrays.asList(statusesToIgnore));
         return this;
+    }
+
+    ResilientCloudOperationExecutor withSleeper(LongConsumer sleeper) {
+        this.sleeper = sleeper;
+        return this;
+    }
+
+    @Override
+    public <T> T execute(Supplier<T> operation) {
+        for (int i = 1; i < retryCount; i++) {
+            try {
+                return operation.get();
+            } catch (RuntimeException e) {
+                handle(e);
+                long waitMillis = computeWaitMillis(e, i);
+                sleeper.accept(waitMillis);
+            }
+        }
+        return operation.get();
     }
 
     public <T> T executeWithExponentialBackoff(Function<Duration, T> operation) {
@@ -85,6 +114,30 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
         LOGGER.warn(MessageFormat.format("Retrying operation that failed with status {0} and message: {1}", e.getStatusCode(),
                                          e.getMessage()),
                     e);
+    }
+
+    private long computeWaitMillis(RuntimeException e, int attemptIndex) {
+        if (e instanceof CloudOperationException) {
+            CloudOperationException cloudException = (CloudOperationException) e;
+            if (cloudException.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                Long retryAfterSeconds = cloudException.getRetryAfterSeconds();
+                if (retryAfterSeconds != null) {
+                    long cappedSeconds = Math.min(retryAfterSeconds, RATE_LIMIT_RETRY_AFTER_CAP_IN_SECONDS);
+                    long waitMillis = cappedSeconds * 1000L;
+                    LOGGER.info(Messages.RATE_LIMITED_BY_CC_WAITING_S, retryAfterSeconds, cappedSeconds);
+                    return waitMillis;
+                }
+                LOGGER.info(Messages.RATE_LIMITED_BY_CC_NO_HEADER_WAITING_S, RATE_LIMIT_FALLBACK_WAIT_IN_MILLIS);
+                return RATE_LIMIT_FALLBACK_WAIT_IN_MILLIS;
+            }
+        }
+        if (attemptIndex >= 2) {
+            long waitMillis = ThreadLocalRandom.current()
+                                               .nextLong(RANDOM_RETRY_MIN_WAIT_IN_MILLIS, RANDOM_RETRY_MAX_WAIT_IN_MILLIS + 1);
+            LOGGER.info(Messages.RANDOM_WAIT_BEFORE_RETRY_S, waitMillis);
+            return waitMillis;
+        }
+        return waitTimeBetweenRetriesInMillis;
     }
 
     private boolean shouldRetry(CloudOperationException e) {

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
@@ -77,7 +77,7 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
         for (long i = 1; i < retryCount; i++) {
             try {
                 return operation.get();
-            } catch (CloudOperationException e) {
+            } catch (RuntimeException e) {
                 handle(e);
                 long waitMillis = computeWaitMillis(e, i);
                 sleeper.accept(waitMillis);
@@ -145,10 +145,10 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
     private long computeRateLimitWaitMillis(CloudOperationException e) {
         Long retryAfterSeconds = e.getRetryAfterSeconds();
         if (retryAfterSeconds == null) {
-            LOGGER.info(Messages.RATE_LIMITED_BY_CC_NO_HEADER_WAITING_S, RATE_LIMIT_FALLBACK_WAIT_IN_MILLIS);
+            LOGGER.info(Messages.RATE_LIMITED_BY_CC_NO_HEADER_WAITING_MS, RATE_LIMIT_FALLBACK_WAIT_IN_MILLIS);
             return RATE_LIMIT_FALLBACK_WAIT_IN_MILLIS;
         }
-        long cappedSeconds = Math.max(1L, Math.min(retryAfterSeconds, RATE_LIMIT_RETRY_AFTER_CAP_IN_SECONDS));
+        long cappedSeconds = Math.clamp(retryAfterSeconds, 1L, RATE_LIMIT_RETRY_AFTER_CAP_IN_SECONDS);
         LOGGER.info(Messages.RATE_LIMITED_BY_CC_WAITING_S, retryAfterSeconds, cappedSeconds);
         return cappedSeconds * 1000L;
     }

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutor.java
@@ -74,10 +74,10 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
 
     @Override
     public <T> T execute(Supplier<T> operation) {
-        for (int i = 1; i < retryCount; i++) {
+        for (long i = 1; i < retryCount; i++) {
             try {
                 return operation.get();
-            } catch (RuntimeException e) {
+            } catch (CloudOperationException e) {
                 handle(e);
                 long waitMillis = computeWaitMillis(e, i);
                 sleeper.accept(waitMillis);
@@ -125,7 +125,7 @@ public class ResilientCloudOperationExecutor extends ResilientOperationExecutor 
                     e);
     }
 
-    private long computeWaitMillis(RuntimeException e, int attemptIndex) {
+    private long computeWaitMillis(RuntimeException e, long attemptIndex) {
         if (e instanceof CloudOperationException) {
             CloudOperationException cloudException = (CloudOperationException) e;
             if (cloudException.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientOperationExecutor.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/util/ResilientOperationExecutor.java
@@ -16,7 +16,7 @@ public class ResilientOperationExecutor {
     private static final long DEFAULT_RETRY_COUNT = 3;
     private static final long DEFAULT_WAIT_TIME_BETWEEN_RETRIES_IN_MILLIS = 5000;
 
-    private long waitTimeBetweenRetriesInMillis = DEFAULT_WAIT_TIME_BETWEEN_RETRIES_IN_MILLIS;
+    protected long waitTimeBetweenRetriesInMillis = DEFAULT_WAIT_TIME_BETWEEN_RETRIES_IN_MILLIS;
     protected long retryCount = DEFAULT_RETRY_COUNT;
 
     public ResilientOperationExecutor withRetryCount(long retryCount) {

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/CloudOperationExceptionTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/CloudOperationExceptionTest.java
@@ -58,5 +58,16 @@ class CloudOperationExceptionTest {
 
         Assertions.assertEquals(60L, e.getRetryAfterSeconds());
     }
+
+    @Test
+    void testFourArgConstructorLeavesRetryAfterSecondsNull() {
+        Throwable cause = new RuntimeException("boom");
+
+        CloudOperationException e = new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS,
+                                                               HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(), "throttled", cause);
+
+        Assertions.assertNull(e.getRetryAfterSeconds());
+        Assertions.assertSame(cause, e.getCause());
+    }
 }
 

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/CloudOperationExceptionTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/CloudOperationExceptionTest.java
@@ -42,4 +42,21 @@ class CloudOperationExceptionTest {
 
         Assertions.assertSame(cause, e.getCause());
     }
+
+    @Test
+    void testRetryAfterSecondsNullByDefault() {
+        CloudOperationException e = new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS);
+
+        Assertions.assertNull(e.getRetryAfterSeconds());
+    }
+
+    @Test
+    void testRetryAfterSecondsStoredWhenProvided() {
+        CloudOperationException e = new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS,
+                                                                HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(),
+                                                                null, null, 60L);
+
+        Assertions.assertEquals(60L, e.getRetryAfterSeconds());
+    }
 }
+

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandlerTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandlerTest.java
@@ -109,6 +109,22 @@ class CloudControllerResponseErrorHandlerTest {
         }
     }
 
+    @Test
+    void testWith429RetainsRetryAfterAndDescriptionWhenBodyPresent() throws IOException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.RETRY_AFTER, "30");
+        ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.TOO_MANY_REQUESTS,
+                                                                     toInputStream("{\"description\":\"rate limit exceeded\"}"), headers);
+        try {
+            handler.handleError(response);
+            fail("Expected an exception");
+        } catch (CloudOperationException e) {
+            assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
+            assertEquals(30L, e.getRetryAfterSeconds());
+            assertEquals("rate limit exceeded", e.getDescription());
+        }
+    }
+
     private void testWithError(ClientHttpResponseMock response, CloudOperationException expectedException) throws IOException {
         try {
             handler.handleError(response);

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandlerTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandlerTest.java
@@ -74,6 +74,24 @@ class CloudControllerResponseErrorHandlerTest {
     }
 
     @Test
+    void testWith429AndZeroRetryAfterHeaderIsAccepted() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.RETRY_AFTER, "0");
+        ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.TOO_MANY_REQUESTS, toInputStream("{}"), headers);
+        CloudOperationException e = assertThrows(CloudOperationException.class, () -> handler.handleError(response));
+        assertEquals(0L, e.getRetryAfterSeconds());
+    }
+
+    @Test
+    void testWith429AndNegativeRetryAfterHeaderIsIgnored() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.RETRY_AFTER, "-1");
+        ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.TOO_MANY_REQUESTS, toInputStream("{}"), headers);
+        CloudOperationException e = assertThrows(CloudOperationException.class, () -> handler.handleError(response));
+        assertNull(e.getRetryAfterSeconds());
+    }
+
+    @Test
     void testWith429AndNonNumericRetryAfterHeader() {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.RETRY_AFTER, "not-a-number");

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandlerTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandlerTest.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.multiapps.controller.client.facade.rest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
@@ -56,6 +57,58 @@ class CloudControllerResponseErrorHandlerTest {
         testWithError(response, expectedException);
     }
 
+    @Test
+    void testWith429AndRetryAfterHeader() throws IOException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.RETRY_AFTER, "60");
+        ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.TOO_MANY_REQUESTS, toInputStream("{}"), headers);
+        try {
+            handler.handleError(response);
+            fail("Expected an exception");
+        } catch (CloudOperationException e) {
+            assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
+            assertEquals(60L, e.getRetryAfterSeconds());
+        }
+    }
+
+    @Test
+    void testWith429WithoutRetryAfterHeader() throws IOException {
+        ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.TOO_MANY_REQUESTS, toInputStream("{}"));
+        try {
+            handler.handleError(response);
+            fail("Expected an exception");
+        } catch (CloudOperationException e) {
+            assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
+            assertNull(e.getRetryAfterSeconds());
+        }
+    }
+
+    @Test
+    void testWith429AndNonNumericRetryAfterHeader() throws IOException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.RETRY_AFTER, "not-a-number");
+        ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.TOO_MANY_REQUESTS, toInputStream("{}"), headers);
+        try {
+            handler.handleError(response);
+            fail("Expected an exception");
+        } catch (CloudOperationException e) {
+            assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
+            assertNull(e.getRetryAfterSeconds());
+        }
+    }
+
+    @Test
+    void testNon429DoesNotSetRetryAfterSeconds() throws IOException {
+        ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.INTERNAL_SERVER_ERROR, toInputStream("{}"));
+        try {
+            handler.handleError(response);
+            fail("Expected an exception");
+        } catch (CloudOperationException e) {
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatusCode());
+            assertNull(e.getRetryAfterSeconds());
+        }
+    }
+
     private void testWithError(ClientHttpResponseMock response, CloudOperationException expectedException) throws IOException {
         try {
             handler.handleError(response);
@@ -87,10 +140,16 @@ class CloudControllerResponseErrorHandlerTest {
 
         private final HttpStatus statusCode;
         private final InputStream body;
+        private final HttpHeaders headers;
 
         public ClientHttpResponseMock(HttpStatus statusCode, InputStream body) {
+            this(statusCode, body, new HttpHeaders());
+        }
+
+        public ClientHttpResponseMock(HttpStatus statusCode, InputStream body, HttpHeaders headers) {
             this.statusCode = statusCode;
             this.body = body;
+            this.headers = headers;
         }
 
         @Override
@@ -100,7 +159,7 @@ class CloudControllerResponseErrorHandlerTest {
 
         @Override
         public HttpHeaders getHeaders() {
-            throw new UnsupportedOperationException();
+            return headers;
         }
 
         @Override
@@ -126,3 +185,4 @@ class CloudControllerResponseErrorHandlerTest {
     }
 
 }
+

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandlerTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/facade/rest/CloudControllerResponseErrorHandlerTest.java
@@ -1,28 +1,26 @@
 package org.cloudfoundry.multiapps.controller.client.facade.rest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
+import org.cloudfoundry.multiapps.controller.client.facade.CloudOperationException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RestClientException;
 
-import org.cloudfoundry.multiapps.controller.client.facade.CloudOperationException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CloudControllerResponseErrorHandlerTest {
 
     private final CloudControllerResponseErrorHandler handler = new CloudControllerResponseErrorHandler();
 
     @Test
-    void testWithV2Error() throws IOException {
+    void testWithV2Error() {
         HttpStatus statusCode = HttpStatus.UNPROCESSABLE_ENTITY;
         ClientHttpResponseMock response = new ClientHttpResponseMock(statusCode, getClass().getResourceAsStream("v2-error.json"));
         CloudOperationException expectedException = new CloudOperationException(statusCode,
@@ -32,7 +30,7 @@ class CloudControllerResponseErrorHandlerTest {
     }
 
     @Test
-    void testWithV3Error() throws IOException {
+    void testWithV3Error() {
         HttpStatus statusCode = HttpStatus.BAD_REQUEST;
         ClientHttpResponseMock response = new ClientHttpResponseMock(statusCode, getClass().getResourceAsStream("v3-error.json"));
         CloudOperationException expectedException = new CloudOperationException(statusCode,
@@ -42,7 +40,7 @@ class CloudControllerResponseErrorHandlerTest {
     }
 
     @Test
-    void testWithInvalidError() throws IOException {
+    void testWithInvalidError() {
         HttpStatus statusCode = HttpStatus.BAD_REQUEST;
         ClientHttpResponseMock response = new ClientHttpResponseMock(statusCode, toInputStream("blabla"));
         CloudOperationException expectedException = new CloudOperationException(statusCode, statusCode.getReasonPhrase());
@@ -50,7 +48,7 @@ class CloudControllerResponseErrorHandlerTest {
     }
 
     @Test
-    void testWithEmptyResponse() throws IOException {
+    void testWithEmptyResponse() {
         HttpStatus statusCode = HttpStatus.BAD_REQUEST;
         ClientHttpResponseMock response = new ClientHttpResponseMock(statusCode, toInputStream("{    }"));
         CloudOperationException expectedException = new CloudOperationException(statusCode, statusCode.getReasonPhrase());
@@ -58,94 +56,66 @@ class CloudControllerResponseErrorHandlerTest {
     }
 
     @Test
-    void testWith429AndRetryAfterHeader() throws IOException {
+    void testWith429AndRetryAfterHeader() {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.RETRY_AFTER, "60");
         ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.TOO_MANY_REQUESTS, toInputStream("{}"), headers);
-        try {
-            handler.handleError(response);
-            fail("Expected an exception");
-        } catch (CloudOperationException e) {
-            assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
-            assertEquals(60L, e.getRetryAfterSeconds());
-        }
+        CloudOperationException e = assertThrows(CloudOperationException.class, () -> handler.handleError(response));
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
+        assertEquals(60L, e.getRetryAfterSeconds());
     }
 
     @Test
-    void testWith429WithoutRetryAfterHeader() throws IOException {
+    void testWith429WithoutRetryAfterHeader() {
         ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.TOO_MANY_REQUESTS, toInputStream("{}"));
-        try {
-            handler.handleError(response);
-            fail("Expected an exception");
-        } catch (CloudOperationException e) {
-            assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
-            assertNull(e.getRetryAfterSeconds());
-        }
+        CloudOperationException e = assertThrows(CloudOperationException.class, () -> handler.handleError(response));
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
+        assertNull(e.getRetryAfterSeconds());
     }
 
     @Test
-    void testWith429AndNonNumericRetryAfterHeader() throws IOException {
+    void testWith429AndNonNumericRetryAfterHeader() {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.RETRY_AFTER, "not-a-number");
         ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.TOO_MANY_REQUESTS, toInputStream("{}"), headers);
-        try {
-            handler.handleError(response);
-            fail("Expected an exception");
-        } catch (CloudOperationException e) {
-            assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
-            assertNull(e.getRetryAfterSeconds());
-        }
+        CloudOperationException e = assertThrows(CloudOperationException.class, () -> handler.handleError(response));
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
+        assertNull(e.getRetryAfterSeconds());
     }
 
     @Test
-    void testNon429DoesNotSetRetryAfterSeconds() throws IOException {
+    void testNon429DoesNotSetRetryAfterSeconds() {
         ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.INTERNAL_SERVER_ERROR, toInputStream("{}"));
-        try {
-            handler.handleError(response);
-            fail("Expected an exception");
-        } catch (CloudOperationException e) {
-            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatusCode());
-            assertNull(e.getRetryAfterSeconds());
-        }
+        CloudOperationException e = assertThrows(CloudOperationException.class, () -> handler.handleError(response));
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatusCode());
+        assertNull(e.getRetryAfterSeconds());
     }
 
     @Test
-    void testWith429RetainsRetryAfterAndDescriptionWhenBodyPresent() throws IOException {
+    void testWith429RetainsRetryAfterAndDescriptionWhenBodyPresent() {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.RETRY_AFTER, "30");
         ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.TOO_MANY_REQUESTS,
                                                                      toInputStream("{\"description\":\"rate limit exceeded\"}"), headers);
-        try {
-            handler.handleError(response);
-            fail("Expected an exception");
-        } catch (CloudOperationException e) {
-            assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
-            assertEquals(30L, e.getRetryAfterSeconds());
-            assertEquals("rate limit exceeded", e.getDescription());
-        }
+        CloudOperationException e = assertThrows(CloudOperationException.class, () -> handler.handleError(response));
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS, e.getStatusCode());
+        assertEquals(30L, e.getRetryAfterSeconds());
+        assertEquals("rate limit exceeded", e.getDescription());
     }
 
-    private void testWithError(ClientHttpResponseMock response, CloudOperationException expectedException) throws IOException {
-        try {
-            handler.handleError(response);
-            fail("Expected an exception");
-        } catch (CloudOperationException exception) {
-            assertEquals(expectedException.getStatusCode(), exception.getStatusCode());
-            assertEquals(expectedException.getStatusText(), exception.getStatusText());
-            assertEquals(expectedException.getDescription(), exception.getDescription());
-        }
+    private void testWithError(ClientHttpResponseMock response, CloudOperationException expectedException) {
+        CloudOperationException exception = assertThrows(CloudOperationException.class, () -> handler.handleError(response));
+        assertEquals(expectedException.getStatusCode(), exception.getStatusCode());
+        assertEquals(expectedException.getStatusText(), exception.getStatusText());
+        assertEquals(expectedException.getDescription(), exception.getDescription());
     }
 
     @Test
-    void testWithNonClientOrServerError() throws IOException {
+    void testWithNonClientOrServerError() {
         HttpStatus statusCode = HttpStatus.PERMANENT_REDIRECT;
         ClientHttpResponseMock response = new ClientHttpResponseMock(HttpStatus.PERMANENT_REDIRECT, null);
-        try {
-            handler.handleError(response);
-            fail("Expected an exception");
-        } catch (RestClientException exception) {
-            assertEquals("Unknown status code [" + statusCode + "]", exception.getMessage());
-        }
+        RestClientException exception = assertThrows(RestClientException.class, () -> handler.handleError(response));
+        assertEquals("Unknown status code [" + statusCode + "]", exception.getMessage());
     }
 
     private InputStream toInputStream(String string) {

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutorTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutorTest.java
@@ -119,6 +119,27 @@ class ResilientCloudOperationExecutorTest {
     }
 
     @Test
+    void testRetryAfterHeaderAtCapIsNotReduced() {
+        List<Long> sleepCalls = new ArrayList<>();
+        executor = new ResilientCloudOperationExecutor().withRetryCount(3)
+                                                        .withSleeper(sleepCalls::add);
+        AtomicInteger attempts = new AtomicInteger();
+        Supplier<String> operation = () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS,
+                                                  HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(),
+                                                  null, null, 120L);
+            }
+            return "ok";
+        };
+
+        executor.execute(operation);
+
+        Assertions.assertEquals(1, sleepCalls.size());
+        Assertions.assertEquals(120_000L, sleepCalls.get(0));
+    }
+
+    @Test
     void testRateLimitFallbackWhenRetryAfterAbsent() {
         List<Long> sleepCalls = new ArrayList<>();
         executor = new ResilientCloudOperationExecutor().withRetryCount(3)
@@ -180,6 +201,44 @@ class ResilientCloudOperationExecutorTest {
         Assertions.assertEquals(2, sleepCalls.size());
         Assertions.assertEquals(0L, sleepCalls.get(0));
         Assertions.assertEquals(deterministicDelay, sleepCalls.get(1));
+    }
+
+    @Test
+    void testRetryableOperationThatNeverSucceedsIsEventuallyRethrown() {
+        List<Long> sleepCalls = new ArrayList<>();
+        executor = new ResilientCloudOperationExecutor().withRetryCount(3)
+                                                        .withWaitTimeBetweenRetriesInMillis(0)
+                                                        .withSleeper(sleepCalls::add)
+                                                        .withRandomDelaySupplier(() -> 0L);
+        AtomicInteger attempts = new AtomicInteger();
+        Supplier<String> operation = () -> {
+            attempts.incrementAndGet();
+            throw new CloudOperationException(HttpStatus.BAD_GATEWAY);
+        };
+
+        Assertions.assertThrows(CloudOperationException.class, () -> executor.execute(operation));
+        Assertions.assertEquals(3, attempts.get());
+        Assertions.assertEquals(2, sleepCalls.size());
+    }
+
+    @Test
+    void testRunnableOverloadIsRetriedThroughOverriddenExecute() {
+        List<Long> sleepCalls = new ArrayList<>();
+        executor = new ResilientCloudOperationExecutor().withRetryCount(3)
+                                                        .withWaitTimeBetweenRetriesInMillis(7_000L)
+                                                        .withSleeper(sleepCalls::add);
+        AtomicInteger attempts = new AtomicInteger();
+        Runnable operation = () -> {
+            if (attempts.incrementAndGet() < 2) {
+                throw new CloudOperationException(HttpStatus.SERVICE_UNAVAILABLE);
+            }
+        };
+
+        executor.execute(operation);
+
+        Assertions.assertEquals(2, attempts.get());
+        Assertions.assertEquals(1, sleepCalls.size());
+        Assertions.assertEquals(7_000L, sleepCalls.get(0));
     }
 }
 

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutorTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutorTest.java
@@ -18,16 +18,20 @@ import org.springframework.http.HttpStatus;
 class ResilientCloudOperationExecutorTest {
 
     private ResilientCloudOperationExecutor executor;
+    private List<Long> sleepCalls;
+    private AtomicInteger attempts;
 
     @BeforeEach
     void setUp() {
+        sleepCalls = new ArrayList<>();
+        attempts = new AtomicInteger();
         executor = new ResilientCloudOperationExecutor().withRetryCount(3)
-                                                        .withWaitTimeBetweenRetriesInMillis(0);
+                                                        .withWaitTimeBetweenRetriesInMillis(0)
+                                                        .withSleeper(sleepCalls::add);
     }
 
     @Test
     void testRetriesOnDefaultIgnoredStatuses() {
-        AtomicInteger attempts = new AtomicInteger();
         Supplier<String> operation = () -> {
             if (attempts.incrementAndGet() < 2) {
                 throw new CloudOperationException(HttpStatus.BAD_GATEWAY);
@@ -43,7 +47,6 @@ class ResilientCloudOperationExecutorTest {
 
     @Test
     void testThrowsImmediatelyOnNonIgnoredStatus() {
-        AtomicInteger attempts = new AtomicInteger();
         Supplier<String> operation = () -> {
             attempts.incrementAndGet();
             throw new CloudOperationException(HttpStatus.NOT_FOUND);
@@ -56,7 +59,6 @@ class ResilientCloudOperationExecutorTest {
 
     @Test
     void testWithStatusesToIgnoreAddsAdditionalRetryableStatuses() {
-        AtomicInteger attempts = new AtomicInteger();
         Supplier<String> operation = () -> {
             if (attempts.incrementAndGet() < 2) {
                 throw new CloudOperationException(HttpStatus.NOT_FOUND);
@@ -89,10 +91,6 @@ class ResilientCloudOperationExecutorTest {
     @ParameterizedTest(name = "{0}: retryAfter={1}s → sleep={2}ms")
     @MethodSource("retryAfterHeaderCappingCases")
     void testRetryAfterHeaderCapping(String description, long retryAfterSeconds, long expectedSleepMillis) {
-        List<Long> sleepCalls = new ArrayList<>();
-        executor = new ResilientCloudOperationExecutor().withRetryCount(3)
-                                                        .withSleeper(sleepCalls::add);
-        AtomicInteger attempts = new AtomicInteger();
         Supplier<String> operation = () -> {
             if (attempts.incrementAndGet() == 1) {
                 throw new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS,
@@ -110,10 +108,6 @@ class ResilientCloudOperationExecutorTest {
 
     @Test
     void testRateLimitFallbackWhenRetryAfterAbsent() {
-        List<Long> sleepCalls = new ArrayList<>();
-        executor = new ResilientCloudOperationExecutor().withRetryCount(3)
-                                                        .withSleeper(sleepCalls::add);
-        AtomicInteger attempts = new AtomicInteger();
         Supplier<String> operation = () -> {
             if (attempts.incrementAndGet() == 1) {
                 throw new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS,
@@ -131,11 +125,9 @@ class ResilientCloudOperationExecutorTest {
 
     @Test
     void testNon429UsesExistingFixedDelay() {
-        List<Long> sleepCalls = new ArrayList<>();
         executor = new ResilientCloudOperationExecutor().withRetryCount(3)
                                                         .withWaitTimeBetweenRetriesInMillis(5_000L)
                                                         .withSleeper(sleepCalls::add);
-        AtomicInteger attempts = new AtomicInteger();
         Supplier<String> operation = () -> {
             if (attempts.incrementAndGet() == 1) {
                 throw new CloudOperationException(HttpStatus.BAD_GATEWAY);
@@ -152,12 +144,10 @@ class ResilientCloudOperationExecutorTest {
     @Test
     void testRandomDelayAppliedForNon429AfterFirstRetry() {
         long deterministicDelay = 45_000L;
-        List<Long> sleepCalls = new ArrayList<>();
         executor = new ResilientCloudOperationExecutor().withRetryCount(4)
                                                         .withWaitTimeBetweenRetriesInMillis(0)
                                                         .withSleeper(sleepCalls::add)
                                                         .withRandomDelaySupplier(() -> deterministicDelay);
-        AtomicInteger attempts = new AtomicInteger();
         Supplier<String> operation = () -> {
             if (attempts.incrementAndGet() < 3) {
                 throw new CloudOperationException(HttpStatus.INTERNAL_SERVER_ERROR);
@@ -174,12 +164,10 @@ class ResilientCloudOperationExecutorTest {
 
     @Test
     void testRetryableOperationThatNeverSucceedsIsEventuallyRethrown() {
-        List<Long> sleepCalls = new ArrayList<>();
         executor = new ResilientCloudOperationExecutor().withRetryCount(3)
                                                         .withWaitTimeBetweenRetriesInMillis(0)
                                                         .withSleeper(sleepCalls::add)
                                                         .withRandomDelaySupplier(() -> 0L);
-        AtomicInteger attempts = new AtomicInteger();
         Supplier<String> operation = () -> {
             attempts.incrementAndGet();
             throw new CloudOperationException(HttpStatus.BAD_GATEWAY);
@@ -192,11 +180,9 @@ class ResilientCloudOperationExecutorTest {
 
     @Test
     void testRunnableOverloadIsRetriedThroughOverriddenExecute() {
-        List<Long> sleepCalls = new ArrayList<>();
         executor = new ResilientCloudOperationExecutor().withRetryCount(3)
                                                         .withWaitTimeBetweenRetriesInMillis(7_000L)
                                                         .withSleeper(sleepCalls::add);
-        AtomicInteger attempts = new AtomicInteger();
         Runnable operation = () -> {
             if (attempts.incrementAndGet() < 2) {
                 throw new CloudOperationException(HttpStatus.SERVICE_UNAVAILABLE);

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutorTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutorTest.java
@@ -4,11 +4,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.cloudfoundry.multiapps.controller.client.facade.CloudOperationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 
 class ResilientCloudOperationExecutorTest {
@@ -76,29 +80,15 @@ class ResilientCloudOperationExecutorTest {
         Assertions.assertNotNull(chained);
     }
 
-    @Test
-    void testRetryAfterHeaderIsHonouredOnRateLimit() {
-        List<Long> sleepCalls = new ArrayList<>();
-        executor = new ResilientCloudOperationExecutor().withRetryCount(3)
-                                                        .withSleeper(sleepCalls::add);
-        AtomicInteger attempts = new AtomicInteger();
-        Supplier<String> operation = () -> {
-            if (attempts.incrementAndGet() == 1) {
-                throw new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS,
-                                                  HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(),
-                                                  null, null, 2L);
-            }
-            return "ok";
-        };
-
-        executor.execute(operation);
-
-        Assertions.assertEquals(1, sleepCalls.size());
-        Assertions.assertEquals(2_000L, sleepCalls.get(0));
+    static Stream<Arguments> retryAfterHeaderCappingCases() {
+        return Stream.of(Arguments.of("below cap", 2L, 2_000L),
+                         Arguments.of("above cap", 300L, 120_000L),
+                         Arguments.of("at cap", 120L, 120_000L));
     }
 
-    @Test
-    void testRetryAfterHeaderCappedAtMaximum() {
+    @ParameterizedTest(name = "{0}: retryAfter={1}s → sleep={2}ms")
+    @MethodSource("retryAfterHeaderCappingCases")
+    void testRetryAfterHeaderCapping(String description, long retryAfterSeconds, long expectedSleepMillis) {
         List<Long> sleepCalls = new ArrayList<>();
         executor = new ResilientCloudOperationExecutor().withRetryCount(3)
                                                         .withSleeper(sleepCalls::add);
@@ -107,7 +97,7 @@ class ResilientCloudOperationExecutorTest {
             if (attempts.incrementAndGet() == 1) {
                 throw new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS,
                                                   HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(),
-                                                  null, null, 300L);
+                                                  null, null, retryAfterSeconds);
             }
             return "ok";
         };
@@ -115,28 +105,7 @@ class ResilientCloudOperationExecutorTest {
         executor.execute(operation);
 
         Assertions.assertEquals(1, sleepCalls.size());
-        Assertions.assertEquals(120_000L, sleepCalls.get(0));
-    }
-
-    @Test
-    void testRetryAfterHeaderAtCapIsNotReduced() {
-        List<Long> sleepCalls = new ArrayList<>();
-        executor = new ResilientCloudOperationExecutor().withRetryCount(3)
-                                                        .withSleeper(sleepCalls::add);
-        AtomicInteger attempts = new AtomicInteger();
-        Supplier<String> operation = () -> {
-            if (attempts.incrementAndGet() == 1) {
-                throw new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS,
-                                                  HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(),
-                                                  null, null, 120L);
-            }
-            return "ok";
-        };
-
-        executor.execute(operation);
-
-        Assertions.assertEquals(1, sleepCalls.size());
-        Assertions.assertEquals(120_000L, sleepCalls.get(0));
+        Assertions.assertEquals(expectedSleepMillis, sleepCalls.get(0));
     }
 
     @Test

--- a/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutorTest.java
+++ b/multiapps-controller-client/src/test/java/org/cloudfoundry/multiapps/controller/client/util/ResilientCloudOperationExecutorTest.java
@@ -1,5 +1,7 @@
 package org.cloudfoundry.multiapps.controller.client.util;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
@@ -73,4 +75,111 @@ class ResilientCloudOperationExecutorTest {
                                                                                        .withStatusesToIgnore(HttpStatus.I_AM_A_TEAPOT);
         Assertions.assertNotNull(chained);
     }
+
+    @Test
+    void testRetryAfterHeaderIsHonouredOnRateLimit() {
+        List<Long> sleepCalls = new ArrayList<>();
+        executor = new ResilientCloudOperationExecutor().withRetryCount(3)
+                                                        .withSleeper(sleepCalls::add);
+        AtomicInteger attempts = new AtomicInteger();
+        Supplier<String> operation = () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS,
+                                                  HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(),
+                                                  null, null, 2L);
+            }
+            return "ok";
+        };
+
+        executor.execute(operation);
+
+        Assertions.assertEquals(1, sleepCalls.size());
+        Assertions.assertEquals(2_000L, sleepCalls.get(0));
+    }
+
+    @Test
+    void testRetryAfterHeaderCappedAtMaximum() {
+        List<Long> sleepCalls = new ArrayList<>();
+        executor = new ResilientCloudOperationExecutor().withRetryCount(3)
+                                                        .withSleeper(sleepCalls::add);
+        AtomicInteger attempts = new AtomicInteger();
+        Supplier<String> operation = () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS,
+                                                  HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(),
+                                                  null, null, 300L);
+            }
+            return "ok";
+        };
+
+        executor.execute(operation);
+
+        Assertions.assertEquals(1, sleepCalls.size());
+        Assertions.assertEquals(120_000L, sleepCalls.get(0));
+    }
+
+    @Test
+    void testRateLimitFallbackWhenRetryAfterAbsent() {
+        List<Long> sleepCalls = new ArrayList<>();
+        executor = new ResilientCloudOperationExecutor().withRetryCount(3)
+                                                        .withSleeper(sleepCalls::add);
+        AtomicInteger attempts = new AtomicInteger();
+        Supplier<String> operation = () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw new CloudOperationException(HttpStatus.TOO_MANY_REQUESTS,
+                                                  HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase(),
+                                                  null, null, null);
+            }
+            return "ok";
+        };
+
+        executor.execute(operation);
+
+        Assertions.assertEquals(1, sleepCalls.size());
+        Assertions.assertEquals(60_000L, sleepCalls.get(0));
+    }
+
+    @Test
+    void testNon429UsesExistingFixedDelay() {
+        List<Long> sleepCalls = new ArrayList<>();
+        executor = new ResilientCloudOperationExecutor().withRetryCount(3)
+                                                        .withWaitTimeBetweenRetriesInMillis(5_000L)
+                                                        .withSleeper(sleepCalls::add);
+        AtomicInteger attempts = new AtomicInteger();
+        Supplier<String> operation = () -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw new CloudOperationException(HttpStatus.BAD_GATEWAY);
+            }
+            return "ok";
+        };
+
+        executor.execute(operation);
+
+        Assertions.assertEquals(1, sleepCalls.size());
+        Assertions.assertEquals(5_000L, sleepCalls.get(0));
+    }
+
+    @Test
+    void testRandomDelayAppliedForNon429AfterFirstRetry() {
+        long deterministicDelay = 45_000L;
+        List<Long> sleepCalls = new ArrayList<>();
+        executor = new ResilientCloudOperationExecutor().withRetryCount(4)
+                                                        .withWaitTimeBetweenRetriesInMillis(0)
+                                                        .withSleeper(sleepCalls::add)
+                                                        .withRandomDelaySupplier(() -> deterministicDelay);
+        AtomicInteger attempts = new AtomicInteger();
+        Supplier<String> operation = () -> {
+            if (attempts.incrementAndGet() < 3) {
+                throw new CloudOperationException(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+            return "ok";
+        };
+
+        executor.execute(operation);
+
+        Assertions.assertEquals(2, sleepCalls.size());
+        Assertions.assertEquals(0L, sleepCalls.get(0));
+        Assertions.assertEquals(deterministicDelay, sleepCalls.get(1));
+    }
 }
+


### PR DESCRIPTION
## Summary

Improves the retry/backoff behaviour of `ResilientCloudOperationExecutor` for Cloud Controller calls so the service degrades more gracefully when the CC is under rate limiting or is unstable.

- **Honour the `Retry-After` header on HTTP 429.** `CloudControllerResponseErrorHandler` now parses the `Retry-After` header on `429 TOO_MANY_REQUESTS` responses and propagates it via a new `CloudOperationException.getRetryAfterSeconds()`. When present, the executor waits for that duration, capped at 120s to avoid excessively long stalls; when the header is absent, it falls back to a 60s wait.
- **Treat 429 as retryable.** `TOO_MANY_REQUESTS` is added to the default set of statuses that are retried.
- **Randomized delay for repeated failures.** After the first failed retry of a non-429 error, the executor waits a randomized interval between 30s and 90s instead of the fixed 5s, spreading out load when the CC is seriously impacted.

The random delay supplier and sleeper are injectable (package-private) purely to make the timing behaviour deterministically testable.

## Acceptance criteria

- Failed CC calls returning `429` respect the `Retry-After` header (capped), and fall back sensibly when it is missing.
- Repeated retries no longer hammer the CC with a fixed short delay; they back off with a randomized wait.

## Tests

Added coverage across three test classes:

- `CloudOperationExceptionTest` — retry-after storage, default null, four-arg constructor leaves it null.
- `CloudControllerResponseErrorHandlerTest` — `Retry-After` parsing on 429 (present, absent, non-numeric), non-429 does not set it, body + header passthrough.
- `ResilientCloudOperationExecutorTest` — retry-after honoured, cap boundary, fallback wait, fixed vs randomized delay routing, retry exhaustion rethrow, Runnable-overload routing.

## Test plan

- [ ] `mvn -pl multiapps-controller-client -am test -Dtest=CloudOperationExceptionTest,CloudControllerResponseErrorHandlerTest,ResilientCloudOperationExecutorTest`