### PR TITLE
Add cf-metadata parameter for user-defined CF labels and annotations

### DIFF
--- a/multiapps-controller-api/src/main/resources/mtarest.yaml
+++ b/multiapps-controller-api/src/main/resources/mtarest.yaml
@@ -110,6 +110,10 @@ paths:
         required: false
         type: "string"
       responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/FileMetadata"
         "201":
           description: "Created"
           schema:
@@ -339,6 +343,10 @@ paths:
         schema:
           $ref: "#/definitions/Operation"
       responses:
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Operation"
         "202":
           description: "Accepted"
         "400":

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/CfUserMetadata.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/CfUserMetadata.java
@@ -1,0 +1,21 @@
+package org.cloudfoundry.multiapps.controller.client.lib.domain;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface CfUserMetadata {
+
+    @Value.Default
+    default Map<String, String> getLabels() {
+        return Collections.emptyMap();
+    }
+
+    @Value.Default
+    default Map<String, String> getAnnotations() {
+        return Collections.emptyMap();
+    }
+
+}

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/CfUserMetadata.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/CfUserMetadata.java
@@ -5,7 +5,12 @@ import java.util.Map;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 @Value.Immutable
+@JsonSerialize(as = ImmutableCfUserMetadata.class)
+@JsonDeserialize(as = ImmutableCfUserMetadata.class)
 public interface CfUserMetadata {
 
     @Value.Default

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/CloudApplicationExtended.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/CloudApplicationExtended.java
@@ -66,6 +66,9 @@ public abstract class CloudApplicationExtended extends CloudApplication {
     @Nullable
     public abstract AttributeUpdateStrategy getAttributesUpdateStrategy();
 
+    @Nullable
+    public abstract CfUserMetadata getUserCfMetadata();
+
     @Value.Immutable
     @JsonSerialize(as = ImmutableCloudApplicationExtended.ImmutableAttributeUpdateStrategy.class)
     @JsonDeserialize(as = ImmutableCloudApplicationExtended.ImmutableAttributeUpdateStrategy.class)

--- a/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/CloudServiceInstanceExtended.java
+++ b/multiapps-controller-client/src/main/java/org/cloudfoundry/multiapps/controller/client/lib/domain/CloudServiceInstanceExtended.java
@@ -53,4 +53,7 @@ public abstract class CloudServiceInstanceExtended extends CloudServiceInstance 
     @Nullable
     public abstract Boolean shouldFailOnTagsUpdateFailure();
 
+    @Nullable
+    public abstract CfUserMetadata getUserCfMetadata();
+
 }

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Messages.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/Messages.java
@@ -95,6 +95,11 @@ public final class Messages {
     public static final String UNSUPPORTED_FILE_FORMAT = "Unsupported file format! \"{0}\" detected";
     public static final String ENCRYPTION_HAS_FAILED = "Encryption has failed! Errored with \"{0}\"";
     public static final String DECRYPTION_HAS_FAILED = "Decryption has failed! Errored with \"{0}\"";
+    public static final String CF_METADATA_RESERVED_LABEL_KEY_0 = "Label key \"{0}\" in cf-metadata is reserved. Keys with the prefix \"mta_\" or the name segments used by the deploy service are managed internally and must not be set by the user.";
+    public static final String CF_METADATA_INVALID_LABEL_KEY_0 = "Label key \"{0}\" in cf-metadata is invalid. Keys must consist of an optional DNS prefix (up to 253 characters) followed by a '/' and a name segment (up to 63 alphanumeric, '-', '_', or '.' characters), or a bare name segment matching the same pattern.";
+    public static final String CF_METADATA_LABEL_VALUE_TOO_LONG_0 = "Label value for key \"{0}\" in cf-metadata exceeds the 63-character limit.";
+    public static final String CF_METADATA_ANNOTATION_VALUE_TOO_LONG_0 = "Annotation value for key \"{0}\" in cf-metadata exceeds the 5000-character limit.";
+    public static final String CF_METADATA_INVALID_TYPE = "Parameter \"cf-metadata\" must be a map with optional keys \"labels\" and \"annotations\", each a map of string to string.";
 
     // Warning messages
     public static final String ENVIRONMENT_VARIABLE_IS_NOT_SET_USING_DEFAULT = "Environment variable \"{0}\" is not set. Using default \"{1}\"...";

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ApplicationCloudModelBuilder.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ApplicationCloudModelBuilder.java
@@ -17,6 +17,7 @@ import org.cloudfoundry.multiapps.controller.client.facade.CloudControllerClient
 import org.cloudfoundry.multiapps.controller.client.facade.domain.CloudRoute;
 import org.cloudfoundry.multiapps.controller.client.facade.domain.CloudTask;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.BindingDetails;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.CfUserMetadata;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudApplicationExtended;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudApplicationExtended.AttributeUpdateStrategy;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.ImmutableBindingDetails;
@@ -32,6 +33,7 @@ import org.cloudfoundry.multiapps.controller.core.model.DeployedMtaApplication;
 import org.cloudfoundry.multiapps.controller.core.model.DeployedMtaApplication.ProductizationState;
 import org.cloudfoundry.multiapps.controller.core.model.SupportedParameters;
 import org.cloudfoundry.multiapps.controller.core.parser.ApplicationAttributeUpdateStrategyParser;
+import org.cloudfoundry.multiapps.controller.core.parser.CfMetadataParser;
 import org.cloudfoundry.multiapps.controller.core.parser.DockerInfoParser;
 import org.cloudfoundry.multiapps.controller.core.parser.MemoryParametersParser;
 import org.cloudfoundry.multiapps.controller.core.parser.ParametersParser;
@@ -98,6 +100,7 @@ public class ApplicationCloudModelBuilder {
         ApplicationRoutesCloudModelBuilder routesCloudModelBuilder = getApplicationRoutesCloudModelBuilder(parametersList);
         Set<CloudRoute> routes = getApplicationRoutes(module);
         Set<CloudRoute> idleRoutes = routesCloudModelBuilder.getIdleApplicationRoutes(module, parametersList);
+        CfUserMetadata userCfMetadata = parseParameters(parametersList, new CfMetadataParser());
         return ImmutableCloudApplicationExtended.builder()
                                                 .name(getApplicationName(module))
                                                 .moduleName(module.getName())
@@ -117,8 +120,10 @@ public class ApplicationCloudModelBuilder {
                                                 .restartParameters(parseParameters(parametersList, new RestartParametersParser()))
                                                 .dockerInfo(parseParameters(parametersList, new DockerInfoParser()))
                                                 .attributesUpdateStrategy(getApplicationAttributesUpdateStrategy(parametersList))
+                                                .userCfMetadata(userCfMetadata)
                                                 .v3Metadata(ApplicationMetadataBuilder.build(deploymentDescriptor, namespace, module,
-                                                                                             getApplicationServices(module)))
+                                                                                             getApplicationServices(module),
+                                                                                             userCfMetadata))
                                                 .build();
     }
 

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ApplicationMetadataBuilder.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ApplicationMetadataBuilder.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.cloudfoundry.client.v3.Metadata;
 import org.cloudfoundry.multiapps.common.util.JsonUtil;
 import org.cloudfoundry.multiapps.common.util.MapUtil;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.CfUserMetadata;
 import org.cloudfoundry.multiapps.controller.core.Constants;
 import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataAnnotations;
 import org.cloudfoundry.multiapps.mta.model.DeploymentDescriptor;
@@ -16,7 +17,8 @@ import org.cloudfoundry.multiapps.mta.model.ProvidedDependency;
 
 public class ApplicationMetadataBuilder {
 
-    public static Metadata build(DeploymentDescriptor deploymentDescriptor, String namespace, Module module, List<String> services) {
+    public static Metadata build(DeploymentDescriptor deploymentDescriptor, String namespace, Module module, List<String> services,
+                                 CfUserMetadata userCfMetadata) {
         String mtaModuleAnnotation = buildMtaModuleAnnotation(module);
         String mtaModuleProvidedDependenciesAnnotation = buildMtaModuleProvidedDependenciesAnnotation(module);
         String mtaServicesAnnotation = buildBoundMtaServicesAnnotation(services);
@@ -26,6 +28,13 @@ public class ApplicationMetadataBuilder {
                                                      .annotation(MtaMetadataAnnotations.MTA_MODULE_PUBLIC_PROVIDED_DEPENDENCIES,
                                                                  mtaModuleProvidedDependenciesAnnotation)
                                                      .annotation(MtaMetadataAnnotations.MTA_MODULE_BOUND_SERVICES, mtaServicesAnnotation);
+
+        if (userCfMetadata != null) {
+            userCfMetadata.getLabels()
+                          .forEach(builder::label);
+            userCfMetadata.getAnnotations()
+                          .forEach(builder::annotation);
+        }
 
         return builder.build();
     }

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ServiceMetadataBuilder.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ServiceMetadataBuilder.java
@@ -7,6 +7,7 @@ import org.cloudfoundry.client.v3.Metadata;
 import org.cloudfoundry.client.v3.Metadata.Builder;
 import org.cloudfoundry.multiapps.common.util.JsonUtil;
 import org.cloudfoundry.multiapps.common.util.MapUtil;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.CfUserMetadata;
 import org.cloudfoundry.multiapps.controller.core.Constants;
 import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataAnnotations;
 import org.cloudfoundry.multiapps.mta.model.DeploymentDescriptor;
@@ -14,11 +15,19 @@ import org.cloudfoundry.multiapps.mta.model.Resource;
 
 public class ServiceMetadataBuilder {
 
-    public static Metadata build(DeploymentDescriptor deploymentDescriptor, String namespace, Resource resource) {
+    public static Metadata build(DeploymentDescriptor deploymentDescriptor, String namespace, Resource resource,
+                                 CfUserMetadata userCfMetadata) {
         String mtaResourceAnnotation = buildMtaResourceAnnotation(resource);
 
         Builder builder = MtaMetadataBuilder.init(deploymentDescriptor, namespace)
                                             .annotation(MtaMetadataAnnotations.MTA_RESOURCE, mtaResourceAnnotation);
+
+        if (userCfMetadata != null) {
+            userCfMetadata.getLabels()
+                          .forEach(builder::label);
+            userCfMetadata.getAnnotations()
+                          .forEach(builder::annotation);
+        }
 
         return builder.build();
     }

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ServicesCloudModelBuilder.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ServicesCloudModelBuilder.java
@@ -9,6 +9,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.cloudfoundry.client.v3.serviceinstances.ServiceInstanceType;
 import org.cloudfoundry.multiapps.common.ContentException;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.CfUserMetadata;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudServiceInstanceExtended;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.ImmutableCloudServiceInstanceExtended;
 import org.cloudfoundry.multiapps.controller.core.Messages;
@@ -18,6 +19,7 @@ import org.cloudfoundry.multiapps.controller.core.util.NameUtil;
 import org.cloudfoundry.multiapps.controller.core.util.SpecialResourceTypesRequiredParametersUtil;
 import org.cloudfoundry.multiapps.mta.model.DeploymentDescriptor;
 import org.cloudfoundry.multiapps.mta.model.Resource;
+import org.cloudfoundry.multiapps.controller.core.parser.CfMetadataParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +67,7 @@ public class ServicesCloudModelBuilder {
         String serviceName = commonServiceParameters.getServiceName();
         Map<String, Object> parameters = resource.getParameters();
         SpecialResourceTypesRequiredParametersUtil.checkRequiredParameters(serviceName, ResourceType.MANAGED_SERVICE, parameters);
+        CfUserMetadata userCfMetadata = new CfMetadataParser().parse(List.of(parameters));
 
         return ImmutableCloudServiceInstanceExtended.builder()
                                                     .name(serviceName)
@@ -88,7 +91,9 @@ public class ServicesCloudModelBuilder {
                                                         commonServiceParameters.failOnServiceParametersUpdateFailure())
                                                     .shouldFailOnPlanUpdateFailure(commonServiceParameters.failOnServicePlanUpdateFailure())
                                                     .shouldFailOnTagsUpdateFailure(commonServiceParameters.failOnServiceTagsUpdateFailure())
-                                                    .v3Metadata(ServiceMetadataBuilder.build(deploymentDescriptor, namespace, resource))
+                                                    .userCfMetadata(userCfMetadata)
+                                                    .v3Metadata(ServiceMetadataBuilder.build(deploymentDescriptor, namespace, resource,
+                                                                                             userCfMetadata))
                                                     .build();
     }
 
@@ -120,7 +125,8 @@ public class ServicesCloudModelBuilder {
                                                         commonServiceParameters.failOnServiceParametersUpdateFailure())
                                                     .shouldFailOnPlanUpdateFailure(commonServiceParameters.failOnServicePlanUpdateFailure())
                                                     .shouldFailOnTagsUpdateFailure(commonServiceParameters.failOnServiceTagsUpdateFailure())
-                                                    .v3Metadata(ServiceMetadataBuilder.build(deploymentDescriptor, namespace, resource))
+                                                    .v3Metadata(ServiceMetadataBuilder.build(deploymentDescriptor, namespace, resource,
+                                                                                             null))
                                                     .build();
     }
 
@@ -137,7 +143,8 @@ public class ServicesCloudModelBuilder {
                                                         commonServiceParameters.failOnServiceParametersUpdateFailure())
                                                     .shouldFailOnPlanUpdateFailure(commonServiceParameters.failOnServicePlanUpdateFailure())
                                                     .shouldFailOnTagsUpdateFailure(commonServiceParameters.failOnServiceTagsUpdateFailure())
-                                                    .v3Metadata(ServiceMetadataBuilder.build(deploymentDescriptor, namespace, resource))
+                                                    .v3Metadata(ServiceMetadataBuilder.build(deploymentDescriptor, namespace, resource,
+                                                                                             null))
                                                     .build();
     }
 

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/SupportedParameters.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/model/SupportedParameters.java
@@ -104,6 +104,7 @@ public class SupportedParameters {
     public static final String VCAP_SERVICES_ENV = "vcap-services";
     public static final String USER_PROVIDED_ENV = "user-provided";
     public static final String DOCKER = "docker";
+    public static final String CF_METADATA = "cf-metadata";
     public static final String TIMESTAMP = "timestamp";
     public static final String ENABLE_PARALLEL_SERVICE_BINDINGS = "enable-parallel-service-bindings";
     public static final String TCP_ROUTES = "tcp";
@@ -205,14 +206,14 @@ public class SupportedParameters {
                                                                APPS_UPLOAD_TIMEOUT, APPS_TASK_EXECUTION_TIMEOUT, APPS_START_TIMEOUT,
                                                                APPS_STAGE_TIMEOUT, SKIP_DEPLOY, APP_FEATURES, READINESS_HEALTH_CHECK_TYPE,
                                                                READINESS_HEALTH_CHECK_HTTP_ENDPOINT, READINESS_HEALTH_CHECK_INTERVAL,
-                                                               READINESS_HEALTH_CHECK_INVOCATION_TIMEOUT);
+                                                               READINESS_HEALTH_CHECK_INVOCATION_TIMEOUT, CF_METADATA);
 
     public static final Set<String> RESOURCE_PARAMETERS = Set.of(APPLY_NAMESPACE, SERVICE_CONFIG, SYSLOG_DRAIN_URL, DEFAULT_CONTAINER_NAME,
                                                                  DEFAULT_SERVICE_NAME, DEFAULT_XS_APP_NAME, SERVICE, SERVICE_KEYS,
                                                                  SERVICE_KEY_NAME, SERVICE_NAME, SERVICE_PLAN, SERVICE_TAGS, SERVICE_BROKER,
                                                                  SKIP_SERVICE_UPDATES, TYPE, PROVIDER_ID, PROVIDER_NID, TARGET,
                                                                  SERVICE_CONFIG_PATH, FILTER, MANAGED, VERSION, PATH, MEMORY,
-                                                                 FAIL_ON_SERVICE_UPDATE, SERVICE_PROVIDER, SERVICE_VERSION);
+                                                                 FAIL_ON_SERVICE_UPDATE, SERVICE_PROVIDER, SERVICE_VERSION, CF_METADATA);
     public static final Set<String> GLOBAL_PARAMETERS = Set.of(KEEP_EXISTING_ROUTES, APPS_UPLOAD_TIMEOUT, APPS_TASK_EXECUTION_TIMEOUT,
                                                                APPS_START_TIMEOUT, APPS_STAGE_TIMEOUT, APPLY_NAMESPACE,
                                                                ENABLE_PARALLEL_DEPLOYMENTS, DEPLOY_MODE, BG_DEPENDENCY_AWARE_STOP_ORDER);

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/CfMetadataParser.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/parser/CfMetadataParser.java
@@ -1,0 +1,61 @@
+package org.cloudfoundry.multiapps.controller.core.parser;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.cloudfoundry.multiapps.common.ContentException;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.CfUserMetadata;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.ImmutableCfUserMetadata;
+import org.cloudfoundry.multiapps.controller.core.Messages;
+import org.cloudfoundry.multiapps.controller.core.model.SupportedParameters;
+import org.cloudfoundry.multiapps.controller.core.validators.parameters.CfMetadataValidator;
+import org.cloudfoundry.multiapps.mta.util.PropertiesUtil;
+
+public class CfMetadataParser implements ParametersParser<CfUserMetadata> {
+
+    private static final String LABELS_KEY = "labels";
+    private static final String ANNOTATIONS_KEY = "annotations";
+
+    @Override
+    public CfUserMetadata parse(List<Map<String, Object>> parametersList) {
+        Object rawValue = PropertiesUtil.getPropertyValue(parametersList, SupportedParameters.CF_METADATA, null);
+        if (rawValue == null) {
+            return ImmutableCfUserMetadata.builder()
+                                          .build();
+        }
+        if (!(rawValue instanceof Map)) {
+            throw new ContentException(Messages.CF_METADATA_INVALID_TYPE);
+        }
+        @SuppressWarnings("unchecked")
+        Map<String, Object> cfMetadataMap = (Map<String, Object>) rawValue;
+        Map<String, String> labels = extractStringMap(cfMetadataMap, LABELS_KEY);
+        Map<String, String> annotations = extractStringMap(cfMetadataMap, ANNOTATIONS_KEY);
+
+        CfUserMetadata result = ImmutableCfUserMetadata.builder()
+                                                       .labels(labels)
+                                                       .annotations(annotations)
+                                                       .build();
+        new CfMetadataValidator().validate(result);
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> extractStringMap(Map<String, Object> parent, String key) {
+        Object value = parent.get(key);
+        if (value == null) {
+            return Collections.emptyMap();
+        }
+        if (!(value instanceof Map)) {
+            throw new ContentException(Messages.CF_METADATA_INVALID_TYPE);
+        }
+        Map<?, ?> rawMap = (Map<?, ?>) value;
+        for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+            if (!(entry.getKey() instanceof String) || (entry.getValue() != null && !(entry.getValue() instanceof String))) {
+                throw new ContentException(Messages.CF_METADATA_INVALID_TYPE);
+            }
+        }
+        return (Map<String, String>) rawMap;
+    }
+
+}

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/validators/parameters/CfMetadataValidator.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/validators/parameters/CfMetadataValidator.java
@@ -1,0 +1,76 @@
+package org.cloudfoundry.multiapps.controller.core.validators.parameters;
+
+import java.text.MessageFormat;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.cloudfoundry.multiapps.common.ContentException;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.CfUserMetadata;
+import org.cloudfoundry.multiapps.controller.core.Messages;
+import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataAnnotations;
+import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataLabels;
+
+public class CfMetadataValidator {
+
+    private static final Pattern KEY_PATTERN = Pattern.compile(
+        "([a-zA-Z0-9][a-zA-Z0-9\\-_.]{0,251}[a-zA-Z0-9]/)?[a-zA-Z0-9][a-zA-Z0-9\\-_.]{0,61}[a-zA-Z0-9]|[a-zA-Z0-9]");
+
+    private static final Set<String> RESERVED_KEY_NAMES = Set.of(
+        MtaMetadataLabels.MTA_ID,
+        MtaMetadataLabels.MTA_NAMESPACE,
+        MtaMetadataLabels.SPACE_GUID,
+        MtaMetadataAnnotations.MTA_ID,
+        MtaMetadataAnnotations.MTA_VERSION,
+        MtaMetadataAnnotations.MTA_NAMESPACE,
+        MtaMetadataAnnotations.MTA_MODULE,
+        MtaMetadataAnnotations.MTA_MODULE_PUBLIC_PROVIDED_DEPENDENCIES,
+        MtaMetadataAnnotations.MTA_MODULE_BOUND_SERVICES,
+        MtaMetadataAnnotations.MTA_RESOURCE);
+
+    private static final String MTA_KEY_PREFIX = "mta_";
+    private static final int MAX_LABEL_VALUE_LENGTH = 63;
+    private static final int MAX_ANNOTATION_VALUE_LENGTH = 5000;
+
+    public void validate(CfUserMetadata metadata) {
+        metadata.getLabels()
+                .forEach((key, value) -> validateLabelEntry(key, value));
+        metadata.getAnnotations()
+                .forEach((key, value) -> validateAnnotationEntry(key, value));
+    }
+
+    private void validateLabelEntry(String key, String value) {
+        validateKeyFormat(key);
+        validateKeyNotReserved(key);
+        if (value != null && value.length() > MAX_LABEL_VALUE_LENGTH) {
+            throw new ContentException(MessageFormat.format(Messages.CF_METADATA_LABEL_VALUE_TOO_LONG_0, key));
+        }
+    }
+
+    private void validateAnnotationEntry(String key, String value) {
+        validateKeyFormat(key);
+        validateKeyNotReserved(key);
+        if (value != null && value.length() > MAX_ANNOTATION_VALUE_LENGTH) {
+            throw new ContentException(MessageFormat.format(Messages.CF_METADATA_ANNOTATION_VALUE_TOO_LONG_0, key));
+        }
+    }
+
+    private void validateKeyFormat(String key) {
+        if (!KEY_PATTERN.matcher(key)
+                        .matches()) {
+            throw new ContentException(MessageFormat.format(Messages.CF_METADATA_INVALID_LABEL_KEY_0, key));
+        }
+    }
+
+    private void validateKeyNotReserved(String key) {
+        String nameSegment = extractNameSegment(key);
+        if (nameSegment.startsWith(MTA_KEY_PREFIX) || RESERVED_KEY_NAMES.contains(nameSegment) || RESERVED_KEY_NAMES.contains(key)) {
+            throw new ContentException(MessageFormat.format(Messages.CF_METADATA_RESERVED_LABEL_KEY_0, key));
+        }
+    }
+
+    private String extractNameSegment(String key) {
+        int slashIndex = key.indexOf('/');
+        return slashIndex >= 0 ? key.substring(slashIndex + 1) : key;
+    }
+
+}

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/validators/parameters/CfMetadataValidator.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/validators/parameters/CfMetadataValidator.java
@@ -16,7 +16,7 @@ import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataLabels;
 public class CfMetadataValidator {
 
     private static final Pattern KEY_PATTERN = Pattern.compile(
-        "([a-zA-Z0-9][a-zA-Z0-9\\-_.]{0,251}[a-zA-Z0-9]/)?[a-zA-Z0-9][a-zA-Z0-9\\-_.]{0,61}[a-zA-Z0-9]|[a-zA-Z0-9]");
+        "([a-zA-Z0-9][a-zA-Z0-9\\-_.]{0,251}[a-zA-Z0-9]/)?([a-zA-Z0-9][a-zA-Z0-9\\-_.]{0,61}[a-zA-Z0-9]|[a-zA-Z0-9])");
 
     private static final Set<String> RESERVED_KEY_NAMES = Collections.unmodifiableSet(
         new HashSet<>(Arrays.asList(MtaMetadataLabels.MTA_ID,

--- a/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/validators/parameters/CfMetadataValidator.java
+++ b/multiapps-controller-core/src/main/java/org/cloudfoundry/multiapps/controller/core/validators/parameters/CfMetadataValidator.java
@@ -1,6 +1,9 @@
 package org.cloudfoundry.multiapps.controller.core.validators.parameters;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -15,17 +18,17 @@ public class CfMetadataValidator {
     private static final Pattern KEY_PATTERN = Pattern.compile(
         "([a-zA-Z0-9][a-zA-Z0-9\\-_.]{0,251}[a-zA-Z0-9]/)?[a-zA-Z0-9][a-zA-Z0-9\\-_.]{0,61}[a-zA-Z0-9]|[a-zA-Z0-9]");
 
-    private static final Set<String> RESERVED_KEY_NAMES = Set.of(
-        MtaMetadataLabels.MTA_ID,
-        MtaMetadataLabels.MTA_NAMESPACE,
-        MtaMetadataLabels.SPACE_GUID,
-        MtaMetadataAnnotations.MTA_ID,
-        MtaMetadataAnnotations.MTA_VERSION,
-        MtaMetadataAnnotations.MTA_NAMESPACE,
-        MtaMetadataAnnotations.MTA_MODULE,
-        MtaMetadataAnnotations.MTA_MODULE_PUBLIC_PROVIDED_DEPENDENCIES,
-        MtaMetadataAnnotations.MTA_MODULE_BOUND_SERVICES,
-        MtaMetadataAnnotations.MTA_RESOURCE);
+    private static final Set<String> RESERVED_KEY_NAMES = Collections.unmodifiableSet(
+        new HashSet<>(Arrays.asList(MtaMetadataLabels.MTA_ID,
+                                   MtaMetadataLabels.MTA_NAMESPACE,
+                                   MtaMetadataLabels.SPACE_GUID,
+                                   MtaMetadataAnnotations.MTA_ID,
+                                   MtaMetadataAnnotations.MTA_VERSION,
+                                   MtaMetadataAnnotations.MTA_NAMESPACE,
+                                   MtaMetadataAnnotations.MTA_MODULE,
+                                   MtaMetadataAnnotations.MTA_MODULE_PUBLIC_PROVIDED_DEPENDENCIES,
+                                   MtaMetadataAnnotations.MTA_MODULE_BOUND_SERVICES,
+                                   MtaMetadataAnnotations.MTA_RESOURCE)));
 
     private static final String MTA_KEY_PREFIX = "mta_";
     private static final int MAX_LABEL_VALUE_LENGTH = 63;

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ApplicationCloudModelBuilderCfMetadataTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ApplicationCloudModelBuilderCfMetadataTest.java
@@ -1,0 +1,86 @@
+package org.cloudfoundry.multiapps.controller.core.cf.v2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.cloudfoundry.multiapps.controller.client.facade.CloudControllerClient;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudApplicationExtended;
+import org.cloudfoundry.multiapps.controller.core.cf.detect.AppSuffixDeterminer;
+import org.cloudfoundry.multiapps.controller.core.helpers.ModuleToDeployHelper;
+import org.cloudfoundry.multiapps.controller.core.model.SupportedParameters;
+import org.cloudfoundry.multiapps.controller.core.util.UserMessageLogger;
+import org.cloudfoundry.multiapps.mta.model.DeploymentDescriptor;
+import org.cloudfoundry.multiapps.mta.model.Module;
+import org.cloudfoundry.multiapps.mta.resolvers.ResolverBuilder;
+import org.cloudfoundry.multiapps.mta.resolvers.v2.DescriptorReferenceResolver;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ApplicationCloudModelBuilderCfMetadataTest {
+
+    private static final AppSuffixDeterminer NO_SUFFIX = new AppSuffixDeterminer(false, false);
+    private static final ModuleToDeployHelper MODULE_HELPER = new ModuleToDeployHelper();
+
+    private ApplicationCloudModelBuilder buildBuilder(DeploymentDescriptor descriptor) {
+        DeploymentDescriptor resolved = new DescriptorReferenceResolver(descriptor, new ResolverBuilder(), new ResolverBuilder(),
+                                                                        Collections.emptySet()).resolve();
+        CloudControllerClient client = Mockito.mock(CloudControllerClient.class);
+        Mockito.when(client.getApplicationRoutes(Mockito.any()))
+               .thenReturn(Collections.emptyList());
+        return new ApplicationCloudModelBuilder.Builder().deploymentDescriptor(resolved)
+                                                         .prettyPrinting(false)
+                                                         .deployId("test-deploy")
+                                                         .userMessageLogger(Mockito.mock(UserMessageLogger.class))
+                                                         .appSuffixDeterminer(NO_SUFFIX)
+                                                         .client(client)
+                                                         .build();
+    }
+
+    private static DeploymentDescriptor descriptorWithModule(Module module) {
+        DeploymentDescriptor descriptor = DeploymentDescriptor.createV3();
+        descriptor.setId("test-mta");
+        descriptor.setVersion("1.0.0");
+        descriptor.setModules(List.of(module));
+        return descriptor;
+    }
+
+    @Test
+    void cfMetadataLabelsFlowThroughToUserCfMetadata() {
+        Module module = Module.createV3()
+                              .setName("my-app")
+                              .setType("application")
+                              .setParameters(Map.of(SupportedParameters.CF_METADATA,
+                                                    Map.of("labels", Map.of("env", "prod"),
+                                                           "annotations", Map.of("owner", "team-a"))));
+
+        ApplicationCloudModelBuilder builder = buildBuilder(descriptorWithModule(module));
+        CloudApplicationExtended app = builder.build(module, MODULE_HELPER);
+
+        assertEquals(Map.of("env", "prod"), app.getUserCfMetadata()
+                                               .getLabels());
+        assertEquals(Map.of("owner", "team-a"), app.getUserCfMetadata()
+                                                   .getAnnotations());
+    }
+
+    @Test
+    void absentCfMetadataProducesEmptyUserCfMetadata() {
+        Module module = Module.createV3()
+                              .setName("my-app")
+                              .setType("application");
+
+        ApplicationCloudModelBuilder builder = buildBuilder(descriptorWithModule(module));
+        CloudApplicationExtended app = builder.build(module, MODULE_HELPER);
+
+        assertTrue(app.getUserCfMetadata()
+                      .getLabels()
+                      .isEmpty());
+        assertTrue(app.getUserCfMetadata()
+                      .getAnnotations()
+                      .isEmpty());
+    }
+
+}

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ApplicationMetadataBuilderTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ApplicationMetadataBuilderTest.java
@@ -1,0 +1,70 @@
+package org.cloudfoundry.multiapps.controller.core.cf.v2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.cloudfoundry.client.v3.Metadata;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.ImmutableCfUserMetadata;
+import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataAnnotations;
+import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataLabels;
+import org.cloudfoundry.multiapps.mta.model.DeploymentDescriptor;
+import org.cloudfoundry.multiapps.mta.model.Module;
+import org.junit.jupiter.api.Test;
+
+class ApplicationMetadataBuilderTest {
+
+    private static DeploymentDescriptor buildDescriptor() {
+        DeploymentDescriptor descriptor = DeploymentDescriptor.createV3();
+        descriptor.setId("test-mta");
+        descriptor.setVersion("1.0.0");
+        return descriptor;
+    }
+
+    private static Module buildModule() {
+        return Module.createV3()
+                     .setName("my-module")
+                     .setType("application");
+    }
+
+    @Test
+    void nullUserCfMetadataProducesOnlyMtaInternalKeys() {
+        Metadata result = ApplicationMetadataBuilder.build(buildDescriptor(), null, buildModule(), List.of(), null);
+
+        assertNotNull(result.getLabels().get(MtaMetadataLabels.MTA_ID));
+        assertNotNull(result.getAnnotations().get(MtaMetadataAnnotations.MTA_ID));
+    }
+
+    @Test
+    void userLabelsAndAnnotationsAreMergedAlongsideMtaInternalKeys() {
+        var userMeta = ImmutableCfUserMetadata.builder()
+                                              .labels(Map.of("env", "staging"))
+                                              .annotations(Map.of("owner", "team-b"))
+                                              .build();
+
+        Metadata result = ApplicationMetadataBuilder.build(buildDescriptor(), null, buildModule(), List.of(), userMeta);
+
+        assertEquals("staging", result.getLabels().get("env"));
+        assertEquals("team-b", result.getAnnotations().get("owner"));
+        assertNotNull(result.getLabels().get(MtaMetadataLabels.MTA_ID));
+        assertNotNull(result.getAnnotations().get(MtaMetadataAnnotations.MTA_ID));
+    }
+
+    @Test
+    void mtaInternalLabelsAlwaysPresentRegardlessOfUserMetadata() {
+        var userMeta = ImmutableCfUserMetadata.builder()
+                                              .labels(Map.of("custom", "value"))
+                                              .build();
+
+        Metadata result = ApplicationMetadataBuilder.build(buildDescriptor(), "ns1", buildModule(), List.of(), userMeta);
+
+        assertTrue(result.getLabels().containsKey(MtaMetadataLabels.MTA_ID));
+        assertTrue(result.getLabels().containsKey(MtaMetadataLabels.MTA_NAMESPACE));
+        assertTrue(result.getAnnotations().containsKey(MtaMetadataAnnotations.MTA_ID));
+        assertTrue(result.getAnnotations().containsKey(MtaMetadataAnnotations.MTA_NAMESPACE));
+    }
+
+}

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ServiceMetadataBuilderTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/cf/v2/ServiceMetadataBuilderTest.java
@@ -1,0 +1,94 @@
+package org.cloudfoundry.multiapps.controller.core.cf.v2;
+
+import java.util.Map;
+
+import org.cloudfoundry.client.v3.Metadata;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.ImmutableCfUserMetadata;
+import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataAnnotations;
+import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataLabels;
+import org.cloudfoundry.multiapps.mta.model.DeploymentDescriptor;
+import org.cloudfoundry.multiapps.mta.model.Resource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceMetadataBuilderTest {
+
+    private static DeploymentDescriptor buildDescriptor() {
+        DeploymentDescriptor descriptor = DeploymentDescriptor.createV3();
+        descriptor.setId("test-mta");
+        descriptor.setVersion("1.0.0");
+        return descriptor;
+    }
+
+    private static Resource buildResource() {
+        return Resource.createV3()
+                       .setName("my-resource");
+    }
+
+    @Test
+    void nullUserCfMetadataProducesOnlyMtaInternalKeys() {
+        Metadata result = ServiceMetadataBuilder.build(buildDescriptor(), null, buildResource(), null);
+
+        assertNotNull(result.getLabels()
+                            .get(MtaMetadataLabels.MTA_ID));
+        assertNotNull(result.getAnnotations()
+                            .get(MtaMetadataAnnotations.MTA_ID));
+        assertNotNull(result.getAnnotations()
+                            .get(MtaMetadataAnnotations.MTA_RESOURCE));
+    }
+
+    @Test
+    void userLabelsAndAnnotationsAreMergedAlongsideMtaInternalKeys() {
+        var userMeta = ImmutableCfUserMetadata.builder()
+                                              .labels(Map.of("env", "staging"))
+                                              .annotations(Map.of("owner", "team-b"))
+                                              .build();
+
+        Metadata result = ServiceMetadataBuilder.build(buildDescriptor(), null, buildResource(), userMeta);
+
+        assertEquals("staging", result.getLabels()
+                                      .get("env"));
+        assertEquals("team-b", result.getAnnotations()
+                                     .get("owner"));
+        assertNotNull(result.getLabels()
+                            .get(MtaMetadataLabels.MTA_ID));
+        assertNotNull(result.getAnnotations()
+                            .get(MtaMetadataAnnotations.MTA_RESOURCE));
+    }
+
+    @Test
+    void mtaInternalKeysAlwaysPresentRegardlessOfUserMetadata() {
+        var userMeta = ImmutableCfUserMetadata.builder()
+                                              .labels(Map.of("custom", "value"))
+                                              .build();
+
+        Metadata result = ServiceMetadataBuilder.build(buildDescriptor(), "ns1", buildResource(), userMeta);
+
+        assertTrue(result.getLabels()
+                         .containsKey(MtaMetadataLabels.MTA_ID));
+        assertTrue(result.getLabels()
+                         .containsKey(MtaMetadataLabels.MTA_NAMESPACE));
+        assertTrue(result.getAnnotations()
+                         .containsKey(MtaMetadataAnnotations.MTA_RESOURCE));
+    }
+
+    @Test
+    void emptyUserCfMetadataLeavesOnlyMtaInternalKeys() {
+        var userMeta = ImmutableCfUserMetadata.builder()
+                                              .build();
+
+        Metadata result = ServiceMetadataBuilder.build(buildDescriptor(), null, buildResource(), userMeta);
+
+        assertNotNull(result.getAnnotations()
+                            .get(MtaMetadataAnnotations.MTA_RESOURCE));
+        assertEquals(result.getAnnotations()
+                           .get(MtaMetadataAnnotations.MTA_RESOURCE),
+                     ServiceMetadataBuilder.build(buildDescriptor(), null, buildResource(), null)
+                                           .getAnnotations()
+                                           .get(MtaMetadataAnnotations.MTA_RESOURCE));
+    }
+
+}

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/CfMetadataParserTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/CfMetadataParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -58,6 +59,31 @@ class CfMetadataParserTest {
     void labelsValueNotAMapThrowsContentException() {
         Map<String, Object> params = Map.of(SupportedParameters.CF_METADATA,
                                             Map.of("labels", "not-a-map"));
+
+        assertThrows(ContentException.class, () -> parser.parse(List.of(params)));
+    }
+
+    @Test
+    void annotationsValueNotAMapThrowsContentException() {
+        Map<String, Object> params = Map.of(SupportedParameters.CF_METADATA,
+                                            Map.of("annotations", "not-a-map"));
+
+        assertThrows(ContentException.class, () -> parser.parse(List.of(params)));
+    }
+
+    @Test
+    void labelsWithNonStringValueThrowsContentException() {
+        Map<String, Object> labels = new HashMap<>();
+        labels.put("count", 42);
+        Map<String, Object> params = Map.of(SupportedParameters.CF_METADATA, Map.of("labels", labels));
+
+        assertThrows(ContentException.class, () -> parser.parse(List.of(params)));
+    }
+
+    @Test
+    void validStructureButReservedKeyIsRejectedByValidation() {
+        Map<String, Object> params = Map.of(SupportedParameters.CF_METADATA,
+                                            Map.of("labels", Map.of("mta_id", "custom")));
 
         assertThrows(ContentException.class, () -> parser.parse(List.of(params)));
     }

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/CfMetadataParserTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/parser/CfMetadataParserTest.java
@@ -1,0 +1,65 @@
+package org.cloudfoundry.multiapps.controller.core.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.cloudfoundry.multiapps.common.ContentException;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.CfUserMetadata;
+import org.cloudfoundry.multiapps.controller.core.model.SupportedParameters;
+import org.junit.jupiter.api.Test;
+
+class CfMetadataParserTest {
+
+    private final CfMetadataParser parser = new CfMetadataParser();
+
+    @Test
+    void parseAbsentCfMetadataReturnsEmpty() {
+        CfUserMetadata result = parser.parse(List.of(Map.of()));
+
+        assertTrue(result.getLabels().isEmpty());
+        assertTrue(result.getAnnotations().isEmpty());
+    }
+
+    @Test
+    void parseLabelsAndAnnotations() {
+        Map<String, Object> params = Map.of(SupportedParameters.CF_METADATA,
+                                            Map.of("labels", Map.of("env", "prod"),
+                                                   "annotations", Map.of("owner", "team-a")));
+
+        CfUserMetadata result = parser.parse(List.of(params));
+
+        assertEquals(Map.of("env", "prod"), result.getLabels());
+        assertEquals(Map.of("owner", "team-a"), result.getAnnotations());
+    }
+
+    @Test
+    void parseLabelsOnly() {
+        Map<String, Object> params = Map.of(SupportedParameters.CF_METADATA,
+                                            Map.of("labels", Map.of("cost-center", "1234")));
+
+        CfUserMetadata result = parser.parse(List.of(params));
+
+        assertEquals(Map.of("cost-center", "1234"), result.getLabels());
+        assertTrue(result.getAnnotations().isEmpty());
+    }
+
+    @Test
+    void cfMetadataNotAMapThrowsContentException() {
+        Map<String, Object> params = Map.of(SupportedParameters.CF_METADATA, "not-a-map");
+
+        assertThrows(ContentException.class, () -> parser.parse(List.of(params)));
+    }
+
+    @Test
+    void labelsValueNotAMapThrowsContentException() {
+        Map<String, Object> params = Map.of(SupportedParameters.CF_METADATA,
+                                            Map.of("labels", "not-a-map"));
+
+        assertThrows(ContentException.class, () -> parser.parse(List.of(params)));
+    }
+
+}

--- a/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/validators/parameters/CfMetadataValidatorTest.java
+++ b/multiapps-controller-core/src/test/java/org/cloudfoundry/multiapps/controller/core/validators/parameters/CfMetadataValidatorTest.java
@@ -1,0 +1,93 @@
+package org.cloudfoundry.multiapps.controller.core.validators.parameters;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+
+import org.cloudfoundry.multiapps.common.ContentException;
+import org.cloudfoundry.multiapps.controller.client.lib.domain.ImmutableCfUserMetadata;
+import org.junit.jupiter.api.Test;
+
+class CfMetadataValidatorTest {
+
+    private final CfMetadataValidator validator = new CfMetadataValidator();
+
+    @Test
+    void validLabelAndAnnotationPassValidation() {
+        var metadata = ImmutableCfUserMetadata.builder()
+                                              .labels(Map.of("env", "prod"))
+                                              .annotations(Map.of("owner", "team-a"))
+                                              .build();
+
+        assertDoesNotThrow(() -> validator.validate(metadata));
+    }
+
+    @Test
+    void labelKeyWithSpaceThrowsInvalidKeyException() {
+        var metadata = ImmutableCfUserMetadata.builder()
+                                              .labels(Map.of("bad key", "value"))
+                                              .build();
+
+        assertThrows(ContentException.class, () -> validator.validate(metadata));
+    }
+
+    @Test
+    void reservedMtaLabelKeyThrowsReservedKeyException() {
+        var metadata = ImmutableCfUserMetadata.builder()
+                                              .labels(Map.of("mta_id", "some-mta"))
+                                              .build();
+
+        ContentException ex = assertThrows(ContentException.class, () -> validator.validate(metadata));
+        assertContains(ex.getMessage(), "reserved");
+    }
+
+    @Test
+    void labelKeyStartingWithMtaUnderscoreThrowsReservedKeyException() {
+        var metadata = ImmutableCfUserMetadata.builder()
+                                              .labels(Map.of("mta_custom", "value"))
+                                              .build();
+
+        ContentException ex = assertThrows(ContentException.class, () -> validator.validate(metadata));
+        assertContains(ex.getMessage(), "reserved");
+    }
+
+    @Test
+    void labelValueExceeding63CharsThrowsTooLongException() {
+        String longValue = "x".repeat(64);
+        var metadata = ImmutableCfUserMetadata.builder()
+                                              .labels(Map.of("valid-key", longValue))
+                                              .build();
+
+        ContentException ex = assertThrows(ContentException.class, () -> validator.validate(metadata));
+        assertContains(ex.getMessage(), "63");
+    }
+
+    @Test
+    void annotationValueExceeding5000CharsThrowsTooLongException() {
+        String longValue = "x".repeat(5001);
+        var metadata = ImmutableCfUserMetadata.builder()
+                                              .annotations(Map.of("valid-key", longValue))
+                                              .build();
+
+        ContentException ex = assertThrows(ContentException.class, () -> validator.validate(metadata));
+        assertContains(ex.getMessage(), "5000");
+    }
+
+    @Test
+    void reservedAnnotationKeyThrowsReservedKeyException() {
+        var metadata = ImmutableCfUserMetadata.builder()
+                                              .annotations(Map.of("mta_resource", "value"))
+                                              .build();
+
+        ContentException ex = assertThrows(ContentException.class, () -> validator.validate(metadata));
+        assertContains(ex.getMessage(), "reserved");
+    }
+
+    private void assertContains(String message, String expected) {
+        if (!message.contains(expected)) {
+            throw new AssertionError("Expected message to contain '" + expected + "' but was: " + message);
+        }
+    }
+
+}

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateAppStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateAppStep.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.function.BooleanSupplier;
@@ -14,6 +15,7 @@ import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import org.cloudfoundry.client.v3.Metadata;
 import org.cloudfoundry.multiapps.common.util.JsonUtil;
 import org.cloudfoundry.multiapps.controller.client.facade.CloudControllerClient;
 import org.cloudfoundry.multiapps.controller.client.facade.CloudCredentials;
@@ -26,6 +28,8 @@ import org.cloudfoundry.multiapps.controller.client.lib.domain.ImmutableCloudApp
 import org.cloudfoundry.multiapps.controller.client.lib.domain.ServiceKeyToInject;
 import org.cloudfoundry.multiapps.controller.core.cf.clients.AppBoundServiceInstanceNamesGetter;
 import org.cloudfoundry.multiapps.controller.core.cf.clients.WebClientFactory;
+import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataAnnotations;
+import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataLabels;
 import org.cloudfoundry.multiapps.controller.core.helpers.ApplicationFileDigestDetector;
 import org.cloudfoundry.multiapps.controller.core.model.BlueGreenApplicationNameSuffix;
 import org.cloudfoundry.multiapps.controller.core.security.token.TokenService;
@@ -250,9 +254,36 @@ public class CreateOrUpdateAppStep extends SyncFlowableStep {
             if (app.getV3Metadata() == null) {
                 return;
             }
-            if (!Objects.equals(existingApp.getV3Metadata(), app.getV3Metadata())) {
+            if (hasUserMetadataChanged(existingApp.getV3Metadata(), app.getV3Metadata())) {
                 client.updateApplicationMetadata(existingApp.getGuid(), app.getV3Metadata());
             }
+        }
+
+        private boolean hasUserMetadataChanged(Metadata existing, Metadata updated) {
+            Set<String> internalLabelKeys = Set.of(MtaMetadataLabels.MTA_ID, MtaMetadataLabels.MTA_NAMESPACE, MtaMetadataLabels.SPACE_GUID,
+                                                   MtaMetadataLabels.AUTOSCALER_LABEL);
+            Set<String> internalAnnotationKeys = Set.of(MtaMetadataAnnotations.MTA_ID, MtaMetadataAnnotations.MTA_VERSION,
+                                                        MtaMetadataAnnotations.MTA_NAMESPACE, MtaMetadataAnnotations.MTA_MODULE,
+                                                        MtaMetadataAnnotations.MTA_MODULE_PUBLIC_PROVIDED_DEPENDENCIES,
+                                                        MtaMetadataAnnotations.MTA_MODULE_BOUND_SERVICES,
+                                                        MtaMetadataAnnotations.MTA_RESOURCE);
+
+            Map<String, String> existingLabels = existing != null ? filterUserKeys(existing.getLabels(), internalLabelKeys)
+                : Map.of();
+            Map<String, String> updatedLabels = filterUserKeys(updated.getLabels(), internalLabelKeys);
+            Map<String, String> existingAnnotations = existing != null
+                ? filterUserKeys(existing.getAnnotations(), internalAnnotationKeys)
+                : Map.of();
+            Map<String, String> updatedAnnotations = filterUserKeys(updated.getAnnotations(), internalAnnotationKeys);
+
+            return !existingLabels.equals(updatedLabels) || !existingAnnotations.equals(updatedAnnotations);
+        }
+
+        private Map<String, String> filterUserKeys(Map<String, String> all, Set<String> internalKeys) {
+            return all.entrySet()
+                      .stream()
+                      .filter(e -> !internalKeys.contains(e.getKey()))
+                      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
 
         private void addCurrentAppDigestToNewEnv(Map<String, String> newAppEnv, Map<String, String> existingAppEnv) {

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateAppStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateAppStep.java
@@ -262,8 +262,8 @@ public class CreateOrUpdateAppStep extends SyncFlowableStep {
         private boolean hasUserMetadataChanged(Metadata existing, Metadata updated) {
             Set<String> internalLabelKeys = Set.of(MtaMetadataLabels.MTA_ID, MtaMetadataLabels.MTA_NAMESPACE, MtaMetadataLabels.SPACE_GUID,
                                                    MtaMetadataLabels.AUTOSCALER_LABEL);
-            Set<String> internalAnnotationKeys = Set.of(MtaMetadataAnnotations.MTA_ID, MtaMetadataAnnotations.MTA_VERSION,
-                                                        MtaMetadataAnnotations.MTA_NAMESPACE, MtaMetadataAnnotations.MTA_MODULE,
+            Set<String> internalAnnotationKeys = Set.of(MtaMetadataAnnotations.MTA_ID, MtaMetadataAnnotations.MTA_NAMESPACE,
+                                                        MtaMetadataAnnotations.MTA_MODULE,
                                                         MtaMetadataAnnotations.MTA_MODULE_PUBLIC_PROVIDED_DEPENDENCIES,
                                                         MtaMetadataAnnotations.MTA_MODULE_BOUND_SERVICES,
                                                         MtaMetadataAnnotations.MTA_RESOURCE);

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateAppStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateAppStep.java
@@ -280,6 +280,9 @@ public class CreateOrUpdateAppStep extends SyncFlowableStep {
         }
 
         private Map<String, String> filterUserKeys(Map<String, String> all, Set<String> internalKeys) {
+            if (all == null) {
+                return Map.of();
+            }
             return all.entrySet()
                       .stream()
                       .filter(e -> !internalKeys.contains(e.getKey()))

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
@@ -220,8 +220,8 @@ public class DetermineServiceCreateUpdateServiceActionsStep extends SyncFlowable
         }
         Set<String> internalLabelKeys = Set.of(MtaMetadataLabels.MTA_ID, MtaMetadataLabels.MTA_NAMESPACE, MtaMetadataLabels.SPACE_GUID,
                                                MtaMetadataLabels.AUTOSCALER_LABEL);
-        Set<String> internalAnnotationKeys = Set.of(MtaMetadataAnnotations.MTA_ID, MtaMetadataAnnotations.MTA_VERSION,
-                                                    MtaMetadataAnnotations.MTA_NAMESPACE, MtaMetadataAnnotations.MTA_MODULE,
+        Set<String> internalAnnotationKeys = Set.of(MtaMetadataAnnotations.MTA_ID, MtaMetadataAnnotations.MTA_NAMESPACE,
+                                                    MtaMetadataAnnotations.MTA_MODULE,
                                                     MtaMetadataAnnotations.MTA_MODULE_PUBLIC_PROVIDED_DEPENDENCIES,
                                                     MtaMetadataAnnotations.MTA_MODULE_BOUND_SERVICES,
                                                     MtaMetadataAnnotations.MTA_RESOURCE);

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
@@ -239,6 +239,9 @@ public class DetermineServiceCreateUpdateServiceActionsStep extends SyncFlowable
     }
 
     private Map<String, String> filterUserKeys(Map<String, String> all, Set<String> internalKeys) {
+        if (all == null) {
+            return Map.of();
+        }
         return all.entrySet()
                   .stream()
                   .filter(e -> !internalKeys.contains(e.getKey()))

--- a/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
+++ b/multiapps-controller-process/src/main/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStep.java
@@ -10,6 +10,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -26,6 +28,8 @@ import org.cloudfoundry.multiapps.controller.client.facade.domain.CloudServiceKe
 import org.cloudfoundry.multiapps.controller.client.facade.domain.ServiceOperation;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.CloudServiceInstanceExtended;
 import org.cloudfoundry.multiapps.controller.client.lib.domain.ImmutableCloudServiceInstanceExtended;
+import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataAnnotations;
+import org.cloudfoundry.multiapps.controller.core.cf.metadata.MtaMetadataLabels;
 import org.cloudfoundry.multiapps.controller.core.cf.v2.ResourceType;
 import org.cloudfoundry.multiapps.controller.core.helpers.MtaArchiveElements;
 import org.cloudfoundry.multiapps.controller.core.security.serialization.DynamicSecureSerialization;
@@ -211,10 +215,34 @@ public class DetermineServiceCreateUpdateServiceActionsStep extends SyncFlowable
     private boolean shouldUpdateMetadata(CloudServiceInstanceExtended service, CloudServiceInstance existingService) {
         Metadata existingMetadata = existingService.getV3Metadata();
         Metadata newMetadata = service.getV3Metadata();
-        if (existingMetadata != null && newMetadata != null) {
-            return !existingMetadata.equals(newMetadata);
+        if (newMetadata == null) {
+            return false;
         }
-        return newMetadata != null;
+        Set<String> internalLabelKeys = Set.of(MtaMetadataLabels.MTA_ID, MtaMetadataLabels.MTA_NAMESPACE, MtaMetadataLabels.SPACE_GUID,
+                                               MtaMetadataLabels.AUTOSCALER_LABEL);
+        Set<String> internalAnnotationKeys = Set.of(MtaMetadataAnnotations.MTA_ID, MtaMetadataAnnotations.MTA_VERSION,
+                                                    MtaMetadataAnnotations.MTA_NAMESPACE, MtaMetadataAnnotations.MTA_MODULE,
+                                                    MtaMetadataAnnotations.MTA_MODULE_PUBLIC_PROVIDED_DEPENDENCIES,
+                                                    MtaMetadataAnnotations.MTA_MODULE_BOUND_SERVICES,
+                                                    MtaMetadataAnnotations.MTA_RESOURCE);
+
+        Map<String, String> existingLabels = existingMetadata != null
+            ? filterUserKeys(existingMetadata.getLabels(), internalLabelKeys)
+            : Map.of();
+        Map<String, String> newLabels = filterUserKeys(newMetadata.getLabels(), internalLabelKeys);
+        Map<String, String> existingAnnotations = existingMetadata != null
+            ? filterUserKeys(existingMetadata.getAnnotations(), internalAnnotationKeys)
+            : Map.of();
+        Map<String, String> newAnnotations = filterUserKeys(newMetadata.getAnnotations(), internalAnnotationKeys);
+
+        return !existingLabels.equals(newLabels) || !existingAnnotations.equals(newAnnotations);
+    }
+
+    private Map<String, String> filterUserKeys(Map<String, String> all, Set<String> internalKeys) {
+        return all.entrySet()
+                  .stream()
+                  .filter(e -> !internalKeys.contains(e.getKey()))
+                  .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private CloudServiceInstanceExtended prepareServiceParameters(ProcessContext context, CloudServiceInstanceExtended service) {

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateStepWithExistingAppTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/CreateOrUpdateStepWithExistingAppTest.java
@@ -18,6 +18,7 @@ import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableCloud
 import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableCloudProcess;
 import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableDockerData;
 import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableDockerInfo;
+import org.cloudfoundry.client.v3.Metadata;
 import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableDropletInfo;
 import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableLifecycle;
 import org.cloudfoundry.multiapps.controller.client.facade.domain.ImmutableStaging;
@@ -504,6 +505,70 @@ class CreateOrUpdateStepWithExistingAppTest extends SyncFlowableStepTest<CreateO
         verify(client).rename(idleAppName, APP_NAME);
         verify(subscriptionService)
             .update(any(), eq(new ConfigurationSubscription(0, "", "", APP_NAME, null, null, null, null, null)));
+    }
+
+    @Test
+    void userLabelChangeTriggersMetadataUpdate() {
+        Metadata existingMetadata = Metadata.builder()
+                                            .label("mta_id", "my-mta")
+                                            .label("env", "staging")
+                                            .build();
+        Metadata updatedMetadata = Metadata.builder()
+                                           .label("mta_id", "my-mta")
+                                           .label("env", "prod")
+                                           .build();
+        CloudApplication existingApplication = getApplicationBuilder(false).v3Metadata(existingMetadata)
+                                                                           .build();
+        CloudApplicationExtended application = getApplicationBuilder(false).v3Metadata(updatedMetadata)
+                                                                           .build();
+        prepareContext(application, false);
+        prepareClient(existingApplication, Set.of(), List.of(), Map.of(), DEFAULT_STAGING, null, null);
+
+        step.execute(execution);
+
+        assertStepFinishedSuccessfully();
+        verify(client).updateApplicationMetadata(existingApplication.getGuid(), updatedMetadata);
+    }
+
+    @Test
+    void onlyMtaInternalLabelChangeDoesNotTriggerMetadataUpdate() {
+        Metadata existingMetadata = Metadata.builder()
+                                            .label("mta_id", "old-mta")
+                                            .label("env", "prod")
+                                            .build();
+        Metadata updatedMetadata = Metadata.builder()
+                                           .label("mta_id", "new-mta")
+                                           .label("env", "prod")
+                                           .build();
+        CloudApplication existingApplication = getApplicationBuilder(false).v3Metadata(existingMetadata)
+                                                                           .build();
+        CloudApplicationExtended application = getApplicationBuilder(false).v3Metadata(updatedMetadata)
+                                                                           .build();
+        prepareContext(application, false);
+        prepareClient(existingApplication, Set.of(), List.of(), Map.of(), DEFAULT_STAGING, null, null);
+
+        step.execute(execution);
+
+        assertStepFinishedSuccessfully();
+        verify(client, never()).updateApplicationMetadata(any(), any());
+    }
+
+    @Test
+    void noExistingMetadataWithUserLabelTriggersMetadataUpdate() {
+        Metadata updatedMetadata = Metadata.builder()
+                                           .label("mta_id", "my-mta")
+                                           .label("env", "prod")
+                                           .build();
+        CloudApplication existingApplication = getApplicationBuilder(false).build();
+        CloudApplicationExtended application = getApplicationBuilder(false).v3Metadata(updatedMetadata)
+                                                                           .build();
+        prepareContext(application, false);
+        prepareClient(existingApplication, Set.of(), List.of(), Map.of(), DEFAULT_STAGING, null, null);
+
+        step.execute(execution);
+
+        assertStepFinishedSuccessfully();
+        verify(client).updateApplicationMetadata(existingApplication.getGuid(), updatedMetadata);
     }
 
     @Override

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStepTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStepTest.java
@@ -444,6 +444,47 @@ class DetermineServiceCreateUpdateServiceActionsStepTest extends SyncFlowableSte
         assertTrue(actions.contains(ServiceAction.UPDATE_METADATA), "Actions should contain UPDATE_METADATA");
     }
 
+    @Test
+    void metadataWithNullAnnotationsAndUserLabelChangeIsHandledWithoutNpe() {
+        CloudMetadata serviceMetadata = ImmutableCloudMetadata.of(UUID.randomUUID());
+        Metadata existingV3Metadata = Metadata.builder()
+                                              .label("mta_id", "my-mta")
+                                              .label("env", "staging")
+                                              .build();
+        Metadata updatedV3Metadata = Metadata.builder()
+                                             .label("mta_id", "my-mta")
+                                             .label("env", "prod")
+                                             .build();
+        var existingService = ImmutableCloudServiceInstanceExtended.builder()
+                                                                   .name(SERVICE_NAME)
+                                                                   .resourceName(SERVICE_NAME)
+                                                                   .metadata(serviceMetadata)
+                                                                   .v3Metadata(existingV3Metadata)
+                                                                   .tags(List.of())
+                                                                   .build();
+        var serviceToProcess = ImmutableCloudServiceInstanceExtended.builder()
+                                                                    .name(SERVICE_NAME)
+                                                                    .resourceName(SERVICE_NAME)
+                                                                    .metadata(serviceMetadata)
+                                                                    .v3Metadata(updatedV3Metadata)
+                                                                    .tags(List.of())
+                                                                    .build();
+
+        context.setVariable(Variables.SERVICE_TO_PROCESS, serviceToProcess);
+        context.setVariable(Variables.SERVICE_KEYS_TO_CREATE, Map.of(SERVICE_NAME, Collections.emptyList()));
+        context.setVariable(Variables.DELETE_SERVICES, false);
+        context.setVariable(Variables.DELETE_SERVICE_KEYS, false);
+        context.setVariable(Variables.SHOULD_BACKUP_PREVIOUS_VERSION, false);
+        Mockito.when(client.getServiceInstance(SERVICE_NAME, false))
+               .thenReturn(existingService);
+
+        step.execute(execution);
+
+        assertStepFinishedSuccessfully();
+        List<ServiceAction> actions = context.getVariable(Variables.SERVICE_ACTIONS_TO_EXCECUTE);
+        assertTrue(actions.contains(ServiceAction.UPDATE_METADATA), "Actions should contain UPDATE_METADATA");
+    }
+
     @Override
     protected DetermineServiceCreateUpdateServiceActionsStep createStep() {
         archiveEntryExtractor = Mockito.mock(ArchiveEntryExtractor.class);

--- a/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStepTest.java
+++ b/multiapps-controller-process/src/test/java/org/cloudfoundry/multiapps/controller/process/steps/DetermineServiceCreateUpdateServiceActionsStepTest.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import org.cloudfoundry.client.v3.Metadata;
 import org.cloudfoundry.client.v3.serviceinstances.ServiceInstanceType;
 import org.cloudfoundry.multiapps.common.test.TestUtil;
 import org.cloudfoundry.multiapps.common.util.JsonUtil;
@@ -323,6 +324,124 @@ class DetermineServiceCreateUpdateServiceActionsStepTest extends SyncFlowableSte
                                                     .metadata(metadata)
                                                     .tags(tags)
                                                     .build();
+    }
+
+    @Test
+    void userLabelChangeTriggersManagedServiceMetadataUpdateAction() {
+        CloudMetadata serviceMetadata = ImmutableCloudMetadata.of(UUID.randomUUID());
+        Metadata existingV3Metadata = Metadata.builder()
+                                              .label("mta_id", "my-mta")
+                                              .label("env", "staging")
+                                              .build();
+        Metadata updatedV3Metadata = Metadata.builder()
+                                             .label("mta_id", "my-mta")
+                                             .label("env", "prod")
+                                             .build();
+        var existingService = ImmutableCloudServiceInstanceExtended.builder()
+                                                                   .name(SERVICE_NAME)
+                                                                   .resourceName(SERVICE_NAME)
+                                                                   .metadata(serviceMetadata)
+                                                                   .v3Metadata(existingV3Metadata)
+                                                                   .tags(List.of())
+                                                                   .build();
+        var serviceToProcess = ImmutableCloudServiceInstanceExtended.builder()
+                                                                    .name(SERVICE_NAME)
+                                                                    .resourceName(SERVICE_NAME)
+                                                                    .metadata(serviceMetadata)
+                                                                    .v3Metadata(updatedV3Metadata)
+                                                                    .tags(List.of())
+                                                                    .build();
+
+        context.setVariable(Variables.SERVICE_TO_PROCESS, serviceToProcess);
+        context.setVariable(Variables.SERVICE_KEYS_TO_CREATE, Map.of(SERVICE_NAME, Collections.emptyList()));
+        context.setVariable(Variables.DELETE_SERVICES, false);
+        context.setVariable(Variables.DELETE_SERVICE_KEYS, false);
+        context.setVariable(Variables.SHOULD_BACKUP_PREVIOUS_VERSION, false);
+        Mockito.when(client.getServiceInstance(SERVICE_NAME, false))
+               .thenReturn(existingService);
+
+        step.execute(execution);
+
+        assertStepFinishedSuccessfully();
+        List<ServiceAction> actions = context.getVariable(Variables.SERVICE_ACTIONS_TO_EXCECUTE);
+        assertTrue(actions.contains(ServiceAction.UPDATE_METADATA), "Actions should contain UPDATE_METADATA");
+    }
+
+    @Test
+    void onlyMtaInternalLabelChangeDoesNotTriggerManagedServiceMetadataUpdateAction() {
+        CloudMetadata serviceMetadata = ImmutableCloudMetadata.of(UUID.randomUUID());
+        Metadata existingV3Metadata = Metadata.builder()
+                                              .label("mta_id", "old-mta")
+                                              .label("env", "prod")
+                                              .build();
+        Metadata updatedV3Metadata = Metadata.builder()
+                                             .label("mta_id", "new-mta")
+                                             .label("env", "prod")
+                                             .build();
+        var existingService = ImmutableCloudServiceInstanceExtended.builder()
+                                                                   .name(SERVICE_NAME)
+                                                                   .resourceName(SERVICE_NAME)
+                                                                   .metadata(serviceMetadata)
+                                                                   .v3Metadata(existingV3Metadata)
+                                                                   .tags(List.of())
+                                                                   .build();
+        var serviceToProcess = ImmutableCloudServiceInstanceExtended.builder()
+                                                                    .name(SERVICE_NAME)
+                                                                    .resourceName(SERVICE_NAME)
+                                                                    .metadata(serviceMetadata)
+                                                                    .v3Metadata(updatedV3Metadata)
+                                                                    .tags(List.of())
+                                                                    .build();
+
+        context.setVariable(Variables.SERVICE_TO_PROCESS, serviceToProcess);
+        context.setVariable(Variables.SERVICE_KEYS_TO_CREATE, Map.of(SERVICE_NAME, Collections.emptyList()));
+        context.setVariable(Variables.DELETE_SERVICES, false);
+        context.setVariable(Variables.DELETE_SERVICE_KEYS, false);
+        context.setVariable(Variables.SHOULD_BACKUP_PREVIOUS_VERSION, false);
+        Mockito.when(client.getServiceInstance(SERVICE_NAME, false))
+               .thenReturn(existingService);
+
+        step.execute(execution);
+
+        assertStepFinishedSuccessfully();
+        List<ServiceAction> actions = context.getVariable(Variables.SERVICE_ACTIONS_TO_EXCECUTE);
+        assertFalse(actions.contains(ServiceAction.UPDATE_METADATA), "Actions should not contain UPDATE_METADATA");
+    }
+
+    @Test
+    void noExistingV3MetadataWithUserLabelTriggersManagedServiceMetadataUpdateAction() {
+        CloudMetadata serviceMetadata = ImmutableCloudMetadata.of(UUID.randomUUID());
+        Metadata updatedV3Metadata = Metadata.builder()
+                                             .label("mta_id", "my-mta")
+                                             .label("env", "prod")
+                                             .build();
+        var existingService = ImmutableCloudServiceInstanceExtended.builder()
+                                                                   .name(SERVICE_NAME)
+                                                                   .resourceName(SERVICE_NAME)
+                                                                   .metadata(serviceMetadata)
+                                                                   .tags(List.of())
+                                                                   .build();
+        var serviceToProcess = ImmutableCloudServiceInstanceExtended.builder()
+                                                                    .name(SERVICE_NAME)
+                                                                    .resourceName(SERVICE_NAME)
+                                                                    .metadata(serviceMetadata)
+                                                                    .v3Metadata(updatedV3Metadata)
+                                                                    .tags(List.of())
+                                                                    .build();
+
+        context.setVariable(Variables.SERVICE_TO_PROCESS, serviceToProcess);
+        context.setVariable(Variables.SERVICE_KEYS_TO_CREATE, Map.of(SERVICE_NAME, Collections.emptyList()));
+        context.setVariable(Variables.DELETE_SERVICES, false);
+        context.setVariable(Variables.DELETE_SERVICE_KEYS, false);
+        context.setVariable(Variables.SHOULD_BACKUP_PREVIOUS_VERSION, false);
+        Mockito.when(client.getServiceInstance(SERVICE_NAME, false))
+               .thenReturn(existingService);
+
+        step.execute(execution);
+
+        assertStepFinishedSuccessfully();
+        List<ServiceAction> actions = context.getVariable(Variables.SERVICE_ACTIONS_TO_EXCECUTE);
+        assertTrue(actions.contains(ServiceAction.UPDATE_METADATA), "Actions should contain UPDATE_METADATA");
     }
 
     @Override


### PR DESCRIPTION
## What

Adds support for a new `cf-metadata` MTA parameter that lets descriptor authors
attach user-defined Cloud Foundry V3 labels and annotations to applications and
managed service instances directly from `mtad.yaml`.

```yaml
modules:
  - name: my-app
    type: org.cloudfoundry.application
    parameters:
      cf-metadata:
        labels:
          commit-id: "abc123"
        annotations:
          description: "Built from the current descriptor"
resources:
  - name: my-service
    type: org.cloudfoundry.managed-service
    parameters:
      cf-metadata:
        labels:
          env: "prod"
```

## Why

Previously, user-defined CF metadata (labels and annotations) could only be set
manually after deployment, which was error-prone and not reproducible from the
MTA descriptor. This change makes that metadata declarative and part of the
deployment lifecycle.

## How

- New `cf-metadata` module/resource parameter registered in `SupportedParameters`.
- `CfMetadataParser` parses the `labels` and `annotations` sub-maps into a new
  `CfUserMetadata` value object.
- `CfMetadataValidator` enforces CF metadata key/value constraints and rejects
  reserved `mta.cloudfoundry.org/` keys with a clear error.
- User metadata is threaded through `CloudApplicationExtended` and
  `CloudServiceInstanceExtended`, and merged into the built `Metadata` by
  `ApplicationMetadataBuilder` and `ServiceMetadataBuilder`.
- Change detection in `CreateOrUpdateAppStep` and
  `DetermineServiceCreateUpdateServiceActionsStep` compares only user-defined
  keys, so updates to MTA-internal metadata no longer trigger spurious CF
  metadata API calls, and user metadata changes correctly trigger an update.

## Behaviour notes

- MTA-internal `mta.cloudfoundry.org/` labels and annotations are always
  preserved; user descriptors cannot overwrite or delete them.
- User-declared label/annotation values support standard descriptor variable
  interpolation.
- MTA archives without `cf-metadata` deploy identically to prior behaviour.

## Tests

- `CfMetadataParserTest`, `CfMetadataValidatorTest`
- `ApplicationMetadataBuilderTest`, `ServiceMetadataBuilderTest`,
  `ApplicationCloudModelBuilderCfMetadataTest`
- `CreateOrUpdateStepWithExistingAppTest`,
  `DetermineServiceCreateUpdateServiceActionsStepTest`

JIRA:LMCROSSITXSADEPLOY-1550