### PR TITLE
Bump tika-core from 3.3.0 to 3.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <bouncycastle.version>2.1.10</bouncycastle.version>
         <apache.compress.version>1.28.0</apache.compress.version>
-        <tika-core.version>3.3.0</tika-core.version>
+        <tika-core.version>3.3.2</tika-core.version>
         <commons-logging.version>1.3.6</commons-logging.version>
         <google-cloud.version>2.70.0</google-cloud.version>
         <google-cloud-nio.version>0.134.0</google-cloud-nio.version>


### PR DESCRIPTION
## What

Upgrades `org.apache.tika:tika-core` from `3.3.0` to `3.3.2` (patch release).

The version is managed via the `tika-core.version` property in the parent POM and consumed by `multiapps-controller-core`.

## Why

Routine dependency maintenance — moving to the latest available patch release of Apache Tika.

## Verification

- `mvn dependency:tree -pl multiapps-controller-core -Dincludes=org.apache.tika:tika-core` resolves `tika-core:3.3.2:compile`.
- `mvn clean test-compile -pl multiapps-controller-core --also-make` — BUILD SUCCESS; no source changes required (patch-level upgrade, no API changes).