### PR TITLE
Bump bcpkix-fips (BouncyCastle FIPS) from 2.1.10 to 2.1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <jaxb-core.version>4.0.7</jaxb-core.version>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
-        <bouncycastle.version>2.1.10</bouncycastle.version>
+        <bouncycastle.version>2.1.12</bouncycastle.version>
         <apache.compress.version>1.28.0</apache.compress.version>
         <tika-core.version>3.3.2</tika-core.version>
         <commons-logging.version>1.3.6</commons-logging.version>


### PR DESCRIPTION
#### Description:

Bumps the BouncyCastle FIPS dependency (`org.bouncycastle:bcpkix-fips`, which transitively pulls `bc-fips`/`bcutil-fips`) from **2.1.10** to **2.1.12** — the latest release. The version is centralized in the root `pom.xml` `<bouncycastle.version>` property, so this single change propagates to all consuming modules (e.g. `multiapps-controller-persistence`).

Routine dependency maintenance to stay current with upstream BouncyCastle FIPS fixes. No source or API changes.

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
