### PR TITLE
Bump httpclient from 5.6.2 to 5.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <commons-io.version>2.21.0</commons-io.version>
         <commons-collections4.version>4.5.0</commons-collections4.version>
         <snakeyaml.version>2.6</snakeyaml.version>
-        <httpclient.version>5.6.2</httpclient.version>
+        <httpclient.version>5.6.4</httpclient.version>
         <eclipselink.version>4.0.9</eclipselink.version>
         <flowable.version>7.2.0</flowable.version>
         <spring.version>6.2.19</spring.version>


### PR DESCRIPTION
#### Description: 
Routine dependency maintenance: upgrade `org.apache.httpcomponents.client5:httpclient5` from 5.6.2 to 5.6.4 (latest stable on Maven Central).

This is a patch-level bump within the 5.6.x line, so it is API-compatible and requires no source changes. Keeps the HTTP client current with upstream bug fixes.

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
