### PR TITLE
Replace inheritVariables with explicit in-mappings for undeployAppSubProcess

### DIFF
--- a/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/rollback-mta.bpmn
+++ b/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/rollback-mta.bpmn
@@ -85,6 +85,7 @@
         <flowable:in source="keepFiles" target="keepFiles"></flowable:in>
         <flowable:in source="appArchiveId" target="appArchiveId"></flowable:in>
         <flowable:in source="mtaExtDescriptorId" target="mtaExtDescriptorId"></flowable:in>
+        <flowable:in source="appToProcess" target="appToProcess"></flowable:in>
       </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="appsToUndeploy" flowable:elementVariable="appToProcess">
         <extensionElements></extensionElements>

--- a/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/rollback-mta.bpmn
+++ b/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/rollback-mta.bpmn
@@ -56,7 +56,36 @@
         <extensionElements></extensionElements>
       </multiInstanceLoopCharacteristics>
     </callActivity>
-    <callActivity id="undeployAppCallActivity" name="Undeploy App Call Activity" flowable:async="true" calledElement="undeployAppSubProcess" flowable:calledElementType="key" flowable:inheritVariables="true" flowable:completeAsync="true" flowable:fallbackToDefaultTenant="false">
+    <callActivity id="undeployAppCallActivity" name="Undeploy App Call Activity" flowable:async="true" calledElement="undeployAppSubProcess" flowable:calledElementType="key" flowable:inheritVariables="false" flowable:completeAsync="true" flowable:fallbackToDefaultTenant="false">
+      <extensionElements>
+        <flowable:in source="appsToUndeploy" target="appsToUndeploy"></flowable:in>
+        <flowable:in source="correlationId" target="correlationId"></flowable:in>
+        <flowable:in source="user" target="user"></flowable:in>
+        <flowable:in source="userGuid" target="userGuid"></flowable:in>
+        <flowable:in source="__SPACE_ID" target="__SPACE_ID"></flowable:in>
+        <flowable:in source="isSecurityEnabled" target="isSecurityEnabled"></flowable:in>
+        <flowable:in source="externalLoggingServiceConfigurations" target="externalLoggingServiceConfigurations"></flowable:in>
+        <flowable:in source="mtaDeploymentDescriptor" target="mtaDeploymentDescriptor"></flowable:in>
+        <flowable:in source="completeMtaDeploymentDescriptor" target="completeMtaDeploymentDescriptor"></flowable:in>
+        <flowable:in source="moduleToDeploy" target="moduleToDeploy"></flowable:in>
+        <flowable:in source="mtaId" target="mtaId"></flowable:in>
+        <flowable:in source="subprocessPhase" target="subprocessPhase"></flowable:in>
+        <flowable:in source="phase" target="phase"></flowable:in>
+        <flowable:in source="deployedMta" target="deployedMta"></flowable:in>
+        <flowable:in source="idleMtaColor" target="idleMtaColor"></flowable:in>
+        <flowable:in source="liveMtaColor" target="liveMtaColor"></flowable:in>
+        <flowable:in source="secureExtensionDescriptorParameterNames" target="secureExtensionDescriptorParameterNames"></flowable:in>
+        <flowable:in source="isDisposableUserProvidedServiceEnabled" target="isDisposableUserProvidedServiceEnabled"></flowable:in>
+        <flowable:in source="disposableUserProvidedServiceName" target="disposableUserProvidedServiceName"></flowable:in>
+        <flowable:in source="processId" target="processId"></flowable:in>
+        <flowable:in source="useLastOperationForServiceBindingDeletion" target="useLastOperationForServiceBindingDeletion"></flowable:in>
+        <flowable:in source="__SERVICE_ID" target="__SERVICE_ID"></flowable:in>
+        <flowable:in source="mtaMajorSchemaVersion" target="mtaMajorSchemaVersion"></flowable:in>
+        <flowable:in source="namespace" target="namespace"></flowable:in>
+        <flowable:in source="keepFiles" target="keepFiles"></flowable:in>
+        <flowable:in source="appArchiveId" target="appArchiveId"></flowable:in>
+        <flowable:in source="mtaExtDescriptorId" target="mtaExtDescriptorId"></flowable:in>
+      </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="appsToUndeploy" flowable:elementVariable="appToProcess">
         <extensionElements></extensionElements>
       </multiInstanceLoopCharacteristics>

--- a/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-bg-deploy.bpmn
+++ b/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-bg-deploy.bpmn
@@ -154,6 +154,7 @@
         <flowable:in source="keepFiles" target="keepFiles"></flowable:in>
         <flowable:in source="appArchiveId" target="appArchiveId"></flowable:in>
         <flowable:in source="mtaExtDescriptorId" target="mtaExtDescriptorId"></flowable:in>
+        <flowable:in source="appToProcess" target="appToProcess"></flowable:in>
       </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="appsToUndeploy" flowable:elementVariable="appToProcess">
         <extensionElements></extensionElements>
@@ -194,6 +195,7 @@
         <flowable:in source="keepFiles" target="keepFiles"></flowable:in>
         <flowable:in source="appArchiveId" target="appArchiveId"></flowable:in>
         <flowable:in source="mtaExtDescriptorId" target="mtaExtDescriptorId"></flowable:in>
+        <flowable:in source="appToProcess" target="appToProcess"></flowable:in>
       </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="appsToUndeploy" flowable:elementVariable="appToProcess">
         <extensionElements></extensionElements>

--- a/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-bg-deploy.bpmn
+++ b/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-bg-deploy.bpmn
@@ -125,7 +125,36 @@
     <sequenceFlow id="sid-59F0AF3A-1E41-4A9D-8C78-9B94151006DE" sourceRef="detectSchemaVersionTask" targetRef="mergeDescriptorsTask"></sequenceFlow>
     <inclusiveGateway id="setUndeployPhaseInclusiveGateway" name="setUndeployPhaseInclusiveGateway"></inclusiveGateway>
     <sequenceFlow id="flow39" sourceRef="deleteSubscriptionsTask" targetRef="deleteDiscontinuedConfigurationEntriesTask"></sequenceFlow>
-    <callActivity id="undeployAppCallActivity" name="Undeploy App Call Activity" flowable:async="true" calledElement="undeployAppSubProcess" flowable:calledElementType="key" flowable:inheritVariables="true" flowable:completeAsync="true" flowable:fallbackToDefaultTenant="false">
+    <callActivity id="undeployAppCallActivity" name="Undeploy App Call Activity" flowable:async="true" calledElement="undeployAppSubProcess" flowable:calledElementType="key" flowable:inheritVariables="false" flowable:completeAsync="true" flowable:fallbackToDefaultTenant="false">
+      <extensionElements>
+        <flowable:in source="appsToUndeploy" target="appsToUndeploy"></flowable:in>
+        <flowable:in source="correlationId" target="correlationId"></flowable:in>
+        <flowable:in source="user" target="user"></flowable:in>
+        <flowable:in source="userGuid" target="userGuid"></flowable:in>
+        <flowable:in source="__SPACE_ID" target="__SPACE_ID"></flowable:in>
+        <flowable:in source="isSecurityEnabled" target="isSecurityEnabled"></flowable:in>
+        <flowable:in source="externalLoggingServiceConfigurations" target="externalLoggingServiceConfigurations"></flowable:in>
+        <flowable:in source="mtaDeploymentDescriptor" target="mtaDeploymentDescriptor"></flowable:in>
+        <flowable:in source="completeMtaDeploymentDescriptor" target="completeMtaDeploymentDescriptor"></flowable:in>
+        <flowable:in source="moduleToDeploy" target="moduleToDeploy"></flowable:in>
+        <flowable:in source="mtaId" target="mtaId"></flowable:in>
+        <flowable:in source="subprocessPhase" target="subprocessPhase"></flowable:in>
+        <flowable:in source="phase" target="phase"></flowable:in>
+        <flowable:in source="deployedMta" target="deployedMta"></flowable:in>
+        <flowable:in source="idleMtaColor" target="idleMtaColor"></flowable:in>
+        <flowable:in source="liveMtaColor" target="liveMtaColor"></flowable:in>
+        <flowable:in source="secureExtensionDescriptorParameterNames" target="secureExtensionDescriptorParameterNames"></flowable:in>
+        <flowable:in source="isDisposableUserProvidedServiceEnabled" target="isDisposableUserProvidedServiceEnabled"></flowable:in>
+        <flowable:in source="disposableUserProvidedServiceName" target="disposableUserProvidedServiceName"></flowable:in>
+        <flowable:in source="processId" target="processId"></flowable:in>
+        <flowable:in source="useLastOperationForServiceBindingDeletion" target="useLastOperationForServiceBindingDeletion"></flowable:in>
+        <flowable:in source="__SERVICE_ID" target="__SERVICE_ID"></flowable:in>
+        <flowable:in source="mtaMajorSchemaVersion" target="mtaMajorSchemaVersion"></flowable:in>
+        <flowable:in source="namespace" target="namespace"></flowable:in>
+        <flowable:in source="keepFiles" target="keepFiles"></flowable:in>
+        <flowable:in source="appArchiveId" target="appArchiveId"></flowable:in>
+        <flowable:in source="mtaExtDescriptorId" target="mtaExtDescriptorId"></flowable:in>
+      </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="appsToUndeploy" flowable:elementVariable="appToProcess">
         <extensionElements></extensionElements>
       </multiInstanceLoopCharacteristics>
@@ -136,7 +165,36 @@
     <serviceTask id="detectApplicationsToRenameTask" name="Detect apps to rename" flowable:async="true" flowable:delegateExpression="${detectApplicationsToRenameStep}"></serviceTask>
     <sequenceFlow id="flow8" sourceRef="detectDeployedMtaTask" targetRef="detectApplicationsToRenameTask"></sequenceFlow>
     <serviceTask id="updateModulesAppNames" name="Update Modules App Names " flowable:async="true" flowable:delegateExpression="${updateModulesAppNames}"></serviceTask>
-    <callActivity id="sid-C6BBB2C9-B681-4FAE-A33C-57CEF185997B" name="Undeploy Old Apps Call Activity" flowable:async="true" calledElement="undeployAppSubProcess" flowable:calledElementType="key" flowable:inheritVariables="true" flowable:completeAsync="true" flowable:fallbackToDefaultTenant="false">
+    <callActivity id="sid-C6BBB2C9-B681-4FAE-A33C-57CEF185997B" name="Undeploy Old Apps Call Activity" flowable:async="true" calledElement="undeployAppSubProcess" flowable:calledElementType="key" flowable:inheritVariables="false" flowable:completeAsync="true" flowable:fallbackToDefaultTenant="false">
+      <extensionElements>
+        <flowable:in source="appsToUndeploy" target="appsToUndeploy"></flowable:in>
+        <flowable:in source="correlationId" target="correlationId"></flowable:in>
+        <flowable:in source="user" target="user"></flowable:in>
+        <flowable:in source="userGuid" target="userGuid"></flowable:in>
+        <flowable:in source="__SPACE_ID" target="__SPACE_ID"></flowable:in>
+        <flowable:in source="isSecurityEnabled" target="isSecurityEnabled"></flowable:in>
+        <flowable:in source="externalLoggingServiceConfigurations" target="externalLoggingServiceConfigurations"></flowable:in>
+        <flowable:in source="mtaDeploymentDescriptor" target="mtaDeploymentDescriptor"></flowable:in>
+        <flowable:in source="completeMtaDeploymentDescriptor" target="completeMtaDeploymentDescriptor"></flowable:in>
+        <flowable:in source="moduleToDeploy" target="moduleToDeploy"></flowable:in>
+        <flowable:in source="mtaId" target="mtaId"></flowable:in>
+        <flowable:in source="subprocessPhase" target="subprocessPhase"></flowable:in>
+        <flowable:in source="phase" target="phase"></flowable:in>
+        <flowable:in source="deployedMta" target="deployedMta"></flowable:in>
+        <flowable:in source="idleMtaColor" target="idleMtaColor"></flowable:in>
+        <flowable:in source="liveMtaColor" target="liveMtaColor"></flowable:in>
+        <flowable:in source="secureExtensionDescriptorParameterNames" target="secureExtensionDescriptorParameterNames"></flowable:in>
+        <flowable:in source="isDisposableUserProvidedServiceEnabled" target="isDisposableUserProvidedServiceEnabled"></flowable:in>
+        <flowable:in source="disposableUserProvidedServiceName" target="disposableUserProvidedServiceName"></flowable:in>
+        <flowable:in source="processId" target="processId"></flowable:in>
+        <flowable:in source="useLastOperationForServiceBindingDeletion" target="useLastOperationForServiceBindingDeletion"></flowable:in>
+        <flowable:in source="__SERVICE_ID" target="__SERVICE_ID"></flowable:in>
+        <flowable:in source="mtaMajorSchemaVersion" target="mtaMajorSchemaVersion"></flowable:in>
+        <flowable:in source="namespace" target="namespace"></flowable:in>
+        <flowable:in source="keepFiles" target="keepFiles"></flowable:in>
+        <flowable:in source="appArchiveId" target="appArchiveId"></flowable:in>
+        <flowable:in source="mtaExtDescriptorId" target="mtaExtDescriptorId"></flowable:in>
+      </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="appsToUndeploy" flowable:elementVariable="appToProcess">
         <extensionElements></extensionElements>
       </multiInstanceLoopCharacteristics>

--- a/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-deploy.bpmn
+++ b/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-deploy.bpmn
@@ -134,6 +134,7 @@
         <flowable:in source="keepFiles" target="keepFiles"></flowable:in>
         <flowable:in source="appArchiveId" target="appArchiveId"></flowable:in>
         <flowable:in source="mtaExtDescriptorId" target="mtaExtDescriptorId"></flowable:in>
+        <flowable:in source="appToProcess" target="appToProcess"></flowable:in>
       </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="appsToUndeploy" flowable:elementVariable="appToProcess">
         <extensionElements></extensionElements>

--- a/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-deploy.bpmn
+++ b/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-deploy.bpmn
@@ -105,7 +105,36 @@
     <sequenceFlow id="sid-25422585-0CF1-4EDA-A191-9FC317F996E6" sourceRef="createSubscriptionsTask" targetRef="deleteSubscriptionsTask"></sequenceFlow>
     <sequenceFlow id="sid-71D9747E-4053-4C4D-B8AF-714F9C35DE48" sourceRef="detectSchemaVersionTask" targetRef="mergeDescriptorsTask"></sequenceFlow>
     <exclusiveGateway id="shouldDeleteDiscontinuedServicesGateway" name="Should Delete Discontinued Services" default="doNotDeleteDiscontinuedServicesFlow"></exclusiveGateway>
-    <callActivity id="undeployAppCallActivity" name="Undeploy App Call Activity" flowable:async="true" calledElement="undeployAppSubProcess" flowable:calledElementType="key" flowable:inheritVariables="true" flowable:completeAsync="true" flowable:fallbackToDefaultTenant="false">
+    <callActivity id="undeployAppCallActivity" name="Undeploy App Call Activity" flowable:async="true" calledElement="undeployAppSubProcess" flowable:calledElementType="key" flowable:inheritVariables="false" flowable:completeAsync="true" flowable:fallbackToDefaultTenant="false">
+      <extensionElements>
+        <flowable:in source="appsToUndeploy" target="appsToUndeploy"></flowable:in>
+        <flowable:in source="correlationId" target="correlationId"></flowable:in>
+        <flowable:in source="user" target="user"></flowable:in>
+        <flowable:in source="userGuid" target="userGuid"></flowable:in>
+        <flowable:in source="__SPACE_ID" target="__SPACE_ID"></flowable:in>
+        <flowable:in source="isSecurityEnabled" target="isSecurityEnabled"></flowable:in>
+        <flowable:in source="externalLoggingServiceConfigurations" target="externalLoggingServiceConfigurations"></flowable:in>
+        <flowable:in source="mtaDeploymentDescriptor" target="mtaDeploymentDescriptor"></flowable:in>
+        <flowable:in source="completeMtaDeploymentDescriptor" target="completeMtaDeploymentDescriptor"></flowable:in>
+        <flowable:in source="moduleToDeploy" target="moduleToDeploy"></flowable:in>
+        <flowable:in source="mtaId" target="mtaId"></flowable:in>
+        <flowable:in source="subprocessPhase" target="subprocessPhase"></flowable:in>
+        <flowable:in source="phase" target="phase"></flowable:in>
+        <flowable:in source="deployedMta" target="deployedMta"></flowable:in>
+        <flowable:in source="idleMtaColor" target="idleMtaColor"></flowable:in>
+        <flowable:in source="liveMtaColor" target="liveMtaColor"></flowable:in>
+        <flowable:in source="secureExtensionDescriptorParameterNames" target="secureExtensionDescriptorParameterNames"></flowable:in>
+        <flowable:in source="isDisposableUserProvidedServiceEnabled" target="isDisposableUserProvidedServiceEnabled"></flowable:in>
+        <flowable:in source="disposableUserProvidedServiceName" target="disposableUserProvidedServiceName"></flowable:in>
+        <flowable:in source="processId" target="processId"></flowable:in>
+        <flowable:in source="useLastOperationForServiceBindingDeletion" target="useLastOperationForServiceBindingDeletion"></flowable:in>
+        <flowable:in source="__SERVICE_ID" target="__SERVICE_ID"></flowable:in>
+        <flowable:in source="mtaMajorSchemaVersion" target="mtaMajorSchemaVersion"></flowable:in>
+        <flowable:in source="namespace" target="namespace"></flowable:in>
+        <flowable:in source="keepFiles" target="keepFiles"></flowable:in>
+        <flowable:in source="appArchiveId" target="appArchiveId"></flowable:in>
+        <flowable:in source="mtaExtDescriptorId" target="mtaExtDescriptorId"></flowable:in>
+      </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="appsToUndeploy" flowable:elementVariable="appToProcess">
         <extensionElements></extensionElements>
       </multiInstanceLoopCharacteristics>

--- a/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-undeploy.bpmn
+++ b/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-undeploy.bpmn
@@ -89,9 +89,6 @@
         <flowable:in source="__SERVICE_ID" target="__SERVICE_ID"></flowable:in>
         <flowable:in source="mtaMajorSchemaVersion" target="mtaMajorSchemaVersion"></flowable:in>
         <flowable:in source="namespace" target="namespace"></flowable:in>
-        <flowable:in source="keepFiles" target="keepFiles"></flowable:in>
-        <flowable:in source="appArchiveId" target="appArchiveId"></flowable:in>
-        <flowable:in source="mtaExtDescriptorId" target="mtaExtDescriptorId"></flowable:in>
         <flowable:in source="appToProcess" target="appToProcess"></flowable:in>
       </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="appsToUndeploy" flowable:elementVariable="appToProcess">

--- a/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-undeploy.bpmn
+++ b/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-undeploy.bpmn
@@ -92,6 +92,7 @@
         <flowable:in source="keepFiles" target="keepFiles"></flowable:in>
         <flowable:in source="appArchiveId" target="appArchiveId"></flowable:in>
         <flowable:in source="mtaExtDescriptorId" target="mtaExtDescriptorId"></flowable:in>
+        <flowable:in source="appToProcess" target="appToProcess"></flowable:in>
       </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="appsToUndeploy" flowable:elementVariable="appToProcess">
         <extensionElements></extensionElements>

--- a/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-undeploy.bpmn
+++ b/multiapps-controller-process/src/main/resources/org/cloudfoundry/multiapps/controller/process/xs2-undeploy.bpmn
@@ -63,7 +63,36 @@
       </multiInstanceLoopCharacteristics>
     </callActivity>
     <exclusiveGateway id="shouldDeleteDiscontinuedServicesGateway" name="Should Delete Discontinued Services" default="doNotDeleteDiscontinuedServicesFlow"></exclusiveGateway>
-    <callActivity id="undeployAppsCallActivity" name="Undeploy App Call Activity" flowable:async="true" calledElement="undeployAppSubProcess" flowable:calledElementType="key" flowable:inheritVariables="true" flowable:completeAsync="true" flowable:fallbackToDefaultTenant="false">
+    <callActivity id="undeployAppsCallActivity" name="Undeploy App Call Activity" flowable:async="true" calledElement="undeployAppSubProcess" flowable:calledElementType="key" flowable:inheritVariables="false" flowable:completeAsync="true" flowable:fallbackToDefaultTenant="false">
+      <extensionElements>
+        <flowable:in source="appsToUndeploy" target="appsToUndeploy"></flowable:in>
+        <flowable:in source="correlationId" target="correlationId"></flowable:in>
+        <flowable:in source="user" target="user"></flowable:in>
+        <flowable:in source="userGuid" target="userGuid"></flowable:in>
+        <flowable:in source="__SPACE_ID" target="__SPACE_ID"></flowable:in>
+        <flowable:in source="isSecurityEnabled" target="isSecurityEnabled"></flowable:in>
+        <flowable:in source="externalLoggingServiceConfigurations" target="externalLoggingServiceConfigurations"></flowable:in>
+        <flowable:in source="mtaDeploymentDescriptor" target="mtaDeploymentDescriptor"></flowable:in>
+        <flowable:in source="completeMtaDeploymentDescriptor" target="completeMtaDeploymentDescriptor"></flowable:in>
+        <flowable:in source="moduleToDeploy" target="moduleToDeploy"></flowable:in>
+        <flowable:in source="mtaId" target="mtaId"></flowable:in>
+        <flowable:in source="subprocessPhase" target="subprocessPhase"></flowable:in>
+        <flowable:in source="phase" target="phase"></flowable:in>
+        <flowable:in source="deployedMta" target="deployedMta"></flowable:in>
+        <flowable:in source="idleMtaColor" target="idleMtaColor"></flowable:in>
+        <flowable:in source="liveMtaColor" target="liveMtaColor"></flowable:in>
+        <flowable:in source="secureExtensionDescriptorParameterNames" target="secureExtensionDescriptorParameterNames"></flowable:in>
+        <flowable:in source="isDisposableUserProvidedServiceEnabled" target="isDisposableUserProvidedServiceEnabled"></flowable:in>
+        <flowable:in source="disposableUserProvidedServiceName" target="disposableUserProvidedServiceName"></flowable:in>
+        <flowable:in source="processId" target="processId"></flowable:in>
+        <flowable:in source="useLastOperationForServiceBindingDeletion" target="useLastOperationForServiceBindingDeletion"></flowable:in>
+        <flowable:in source="__SERVICE_ID" target="__SERVICE_ID"></flowable:in>
+        <flowable:in source="mtaMajorSchemaVersion" target="mtaMajorSchemaVersion"></flowable:in>
+        <flowable:in source="namespace" target="namespace"></flowable:in>
+        <flowable:in source="keepFiles" target="keepFiles"></flowable:in>
+        <flowable:in source="appArchiveId" target="appArchiveId"></flowable:in>
+        <flowable:in source="mtaExtDescriptorId" target="mtaExtDescriptorId"></flowable:in>
+      </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="false" flowable:collection="appsToUndeploy" flowable:elementVariable="appToProcess">
         <extensionElements></extensionElements>
       </multiInstanceLoopCharacteristics>


### PR DESCRIPTION
#### Description:

Removes the implicit full-scope variable inheritance from every `undeployAppSubProcess` call activity in the process definitions. All 5 call sites previously used `flowable:inheritVariables="true"`, which passes the entire parent process variable scope into the subprocess. This creates hidden coupling and can cause variables to leak unintentionally between process instances in multi-instance scenarios.

**What changed:** each call site now sets `flowable:inheritVariables="false"` and declares an explicit list of 27 `flowable:in` variable mappings, so the subprocess receives exactly the variables it needs and nothing more. This mirrors the pattern already applied to the `processBatches` subprocess in #1893.

**Affected BPMN files (4 files, 5 call sites):**
- `rollback-mta.bpmn` (1 call site)
- `xs2-bg-deploy.bpmn` (2 call sites)
- `xs2-deploy.bpmn` (1 call site)
- `xs2-undeploy.bpmn` (1 call site)

**Areas to focus on:** please verify the 27-variable `flowable:in` list is complete for each call site — a missing mapping would surface as an unset variable inside `undeployAppSubProcess` at runtime rather than at build time.

Reference: JIRA:LMCROSSITXSADEPLOY-3028

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
