### PR TITLE
Adopt Tomcat 11 runtime for CF MTA Deploy Service

### DIFF
--- a/multiapps-controller-web/manifests/manifest.yml
+++ b/multiapps-controller-web/manifests/manifest.yml
@@ -15,7 +15,10 @@ applications:
       VERSION: ${project.version}
       XS_TYPE: CF
       DB_TYPE: POSTGRESQL
-      CATALINA_OPTS: "-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"
+      # Encoded forward slashes (%2F) are enabled via the Tomcat connector attribute
+      # encodedSolidusHandling="decode"; the org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH
+      # system property was removed in Tomcat 11 and has no effect.
+      JBP_CONFIG_RESOURCE_CONFIGURATION: "['tomcat/conf/server.xml': {'connector.encodedSolidusHandling': 'decode'}]"
       JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "25.+" } }'
       JBP_CONFIG_TOMCAT: '{ tomcat: { version: 11.+ } }'
       JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'

--- a/multiapps-controller-web/manifests/manifest.yml
+++ b/multiapps-controller-web/manifests/manifest.yml
@@ -17,7 +17,7 @@ applications:
       DB_TYPE: POSTGRESQL
       CATALINA_OPTS: "-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"
       JBP_CONFIG_SAP_MACHINE_JRE: '{ jre: { version: "25.+" } }'
-      JBP_CONFIG_TOMCAT: '{ tomcat: { version: 10.+ } }'
+      JBP_CONFIG_TOMCAT: '{ tomcat: { version: 11.+ } }'
       JBP_CONFIG_COMPONENTS: '{jres: ["JavaBuildpack::Jre::SapMachineJRE"]}'
       JAVA_OPTS: '-XX:+HeapDumpOnOutOfMemoryError -XX:MaxDirectMemorySize=192m -Xshare:off -XX:MaxMetaspaceSize=300m -XX:+ErrorFileToStdout -XX:TrimNativeHeapInterval=10000 -Dio.netty.noPreferDirect=true -Dio.netty.maxDirectMemory=0'
       PLATFORM: >


### PR DESCRIPTION
Bump JBP_CONFIG_TOMCAT from 10.+ to 11.+ in the CF manifest. The application already compiles and runs against the Jakarta namespace and Servlet 6.1 API, so this is a runtime configuration-only change.

LMCROSSITXSADEPLOY-3627

#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->


#### Issue: <!-- Link to a Github Issue, delete if not applicable -->

